### PR TITLE
opt: prevent panic from failure on creating channel

### DIFF
--- a/src/gateway/unix.rs
+++ b/src/gateway/unix.rs
@@ -16,10 +16,14 @@ pub fn get_default_gateway(interface_name: String) -> Result<Gateway, String> {
         bpf_fd_attempts: 1000,
         promiscuous: false,
     };
-    let (mut _tx, mut rx) = match socket::channel(interface_name, config) {
-        Ok(socket::Channel::Ethernet(tx, rx)) => (tx, rx),
-        Err(e) => panic!("Failed to create channel {}", e),
-    };
+    let (mut _tx, mut rx);
+    match socket::channel(interface_name, config) {
+        Ok(socket::Channel::Ethernet(etx, erx)) => {
+            _tx = etx;
+            rx = erx;
+        },
+        Err(e) => return Err(format!("Failed to create channel {}", e)),
+    }
     match super::send_udp_packet() {
         Ok(_) => (),
         Err(e) => return Err(format!("Failed to send UDP packet {}", e)),


### PR DESCRIPTION
I've encountered panic on macOS virtual machine with function call `get_default_gateway`, which crashed the whole app and I cannot handle this panic as an error.

This PR removes the `panic` function in runtime code of this plugin, which prevent unnecessary crash for the hosted app.