### PR TITLE
feat: Android compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,13 @@ license = "MIT"
 libc = "0.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
+# DL Open
 dlopen = "0.1.8"
 once_cell = "1.17.1"
+# netlink
+netlink-packet-core = "0.5"
+netlink-packet-route = "0.15"
+netlink-sys = "0.8"
 
 [target.'cfg(windows)'.dependencies]
 memalloc = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ libc = "0.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
 # DL Open
-dlopen = "0.1.8"
-once_cell = "1.17.1"
+dlopen2 = "0.4"
+once_cell = "1"
 # netlink
 netlink-packet-core = "0.5"
 netlink-packet-route = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,6 @@ license = "MIT"
 libc = "0.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
-# DL Open
-dlopen = "0.1.8"
-once_cell = "1.17.1"
 # netlink
 netlink-packet-core = "0.5"
 netlink-packet-route = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ license = "MIT"
 libc = "0.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
+# DL Open
+dlopen = "0.1.8"
+once_cell = "1.17.1"
 # netlink
 netlink-packet-core = "0.5"
 netlink-packet-route = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ license = "MIT"
 [dependencies]
 libc = "0.2"
 
+[target.'cfg(target_os = "android")'.dependencies]
+dlopen = "0.1.8"
+once_cell = "1.17.1"
+
 [target.'cfg(windows)'.dependencies]
 memalloc = "0.1.0"
 

--- a/src/interface/android.rs
+++ b/src/interface/android.rs
@@ -164,7 +164,6 @@ mod netlink {
                                 ifaces.push(interface);
                             }
                             RtnlMessage::NewAddress(addr_msg) => {
-                                println!("NewAddress: {:?}", addr_msg);
                                 if let Some(interface) =
                                     ifaces.iter_mut().find(|i| i.index == addr_msg.header.index)
                                 {

--- a/src/interface/android.rs
+++ b/src/interface/android.rs
@@ -1,46 +1,7 @@
-use once_cell::sync::OnceCell;
+use crate::interface::Interface;
 
-pub fn get_libc_ifaddrs() -> Option<(
-    unsafe extern "C" fn(*mut *mut libc::ifaddrs) -> libc::c_int,
-    unsafe extern "C" fn(*mut libc::ifaddrs),
-)> {
-    match (get_getifaddrs(), get_freeifaddrs()) {
-        (Some(a), Some(b)) => Some((a, b)),
-        _ => None,
-    }
-}
-
-fn load_symbol<T>(sym: &'static str) -> Option<T> {
-    const LIB_NAME: &str = "libc.so";
-
-    println!("loading symbol: {} from {}", sym, LIB_NAME);
-    match dlopen::raw::Library::open(LIB_NAME) {
-        Ok(lib) => match unsafe { lib.symbol::<T>(sym) } {
-            Ok(val) => Some(val),
-            Err(err) => {
-                eprintln!("failed to load symbol {} from {}: {:?}", sym, LIB_NAME, err);
-                None
-            }
-        },
-        Err(err) => {
-            eprintln!("failed to load {}: {:?}", LIB_NAME, err);
-            None
-        }
-    }
-}
-
-fn get_getifaddrs() -> Option<unsafe extern "C" fn(*mut *mut libc::ifaddrs) -> libc::c_int> {
-    static INSTANCE: OnceCell<
-        Option<unsafe extern "C" fn(*mut *mut libc::ifaddrs) -> libc::c_int>,
-    > = OnceCell::new();
-
-    *INSTANCE.get_or_init(|| load_symbol("getifaddrs"))
-}
-
-fn get_freeifaddrs() -> Option<unsafe extern "C" fn(*mut libc::ifaddrs)> {
-    static INSTANCE: OnceCell<Option<unsafe extern "C" fn(*mut libc::ifaddrs)>> = OnceCell::new();
-
-    *INSTANCE.get_or_init(|| load_symbol("freeifaddrs"))
+pub fn unix_interfaces() -> Vec<Interface> {
+    netlink::unix_interfaces()
 }
 
 mod netlink {

--- a/src/interface/android.rs
+++ b/src/interface/android.rs
@@ -13,7 +13,6 @@ pub fn get_libc_ifaddrs() -> Option<(
 fn load_symbol<T>(sym: &'static str) -> Option<T> {
     const LIB_NAME: &str = "libc.so";
 
-    println!("loading symbol: {} from {}", sym, LIB_NAME);
     match dlopen::raw::Library::open(LIB_NAME) {
         Ok(lib) => match unsafe { lib.symbol::<T>(sym) } {
             Ok(val) => Some(val),

--- a/src/interface/android.rs
+++ b/src/interface/android.rs
@@ -1,0 +1,64 @@
+use once_cell::sync::OnceCell;
+
+fn load_symbol<T>(sym: &'static str) -> Option<T> {
+    const LIB_NAME: &str = "libc.so";
+
+    println!("loading symbol: {} from {}", sym, LIB_NAME);
+    match dlopen::raw::Library::open(LIB_NAME) {
+        Ok(lib) => match unsafe { lib.symbol::<T>(sym) } {
+            Ok(val) => Some(val),
+            Err(err) => {
+                eprintln!("failed to load symbol {} from {}: {:?}", sym, LIB_NAME, err);
+                None
+            }
+        },
+        Err(err) => {
+            eprintln!("failed to load {}: {:?}", LIB_NAME, err);
+            None
+        }
+    }
+}
+
+fn get_getifaddrs() -> Option<unsafe extern "C" fn(*mut *mut libc::ifaddrs) -> libc::c_int> {
+    static INSTANCE: OnceCell<
+        Option<unsafe extern "C" fn(*mut *mut libc::ifaddrs) -> libc::c_int>,
+    > = OnceCell::new();
+
+    *INSTANCE.get_or_init(|| load_symbol("getifaddrs"))
+}
+
+fn get_freeifaddrs() -> Option<unsafe extern "C" fn(*mut libc::ifaddrs)> {
+    static INSTANCE: OnceCell<Option<unsafe extern "C" fn(*mut libc::ifaddrs)>> = OnceCell::new();
+
+    *INSTANCE.get_or_init(|| load_symbol("freeifaddrs"))
+}
+
+pub unsafe fn getifaddrs(ifap: *mut *mut libc::ifaddrs) -> libc::c_int {
+    // Android is complicated
+
+    // API 24+ contains the getifaddrs and freeifaddrs functions but the NDK doesn't
+    // expose those functions in ifaddrs.h when the minimum supported SDK is lower than 24
+    // and therefore we need to load them manually.
+    if let Some(dyn_getifaddrs) = get_getifaddrs() {
+        return dyn_getifaddrs(ifap);
+    }
+
+    // If API < 24 (or we can't load libc for some other reason), we fallback to using netlink
+    netlink_getifaddrs(ifap)
+}
+
+pub unsafe fn freeifaddrs(ifa: *mut libc::ifaddrs) {
+    if let Some(dyn_freeifaddrs) = get_freeifaddrs() {
+        return dyn_freeifaddrs(ifa);
+    }
+
+    netlink_freeifaddrs(ifa)
+}
+
+unsafe fn netlink_getifaddrs(ifap: *mut *mut libc::ifaddrs) -> libc::c_int {
+    todo!()
+}
+
+unsafe fn netlink_freeifaddrs(ifa: *mut libc::ifaddrs) {
+    todo!()
+}

--- a/src/interface/android.rs
+++ b/src/interface/android.rs
@@ -56,166 +56,238 @@ mod netlink {
         LinkMessage, RtnlMessage,
     };
     use netlink_sys::{protocols::NETLINK_ROUTE, Socket};
+    use std::io;
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     use crate::interface::{Interface, InterfaceType, Ipv4Net, Ipv6Net, MacAddr};
 
     pub fn unix_interfaces() -> Vec<Interface> {
-        let socket = Socket::new(NETLINK_ROUTE).unwrap();
-
         let mut ifaces = Vec::new();
-        enumerate_netlink(
-            &socket,
-            RtnlMessage::GetLink(LinkMessage::default()),
-            &mut ifaces,
-        );
-        enumerate_netlink(
-            &socket,
-            RtnlMessage::GetAddress(AddressMessage::default()),
-            &mut ifaces,
-        );
-
+        if let Ok(socket) = Socket::new(NETLINK_ROUTE) {
+            if let Err(err) = enumerate_netlink(
+                &socket,
+                RtnlMessage::GetLink(LinkMessage::default()),
+                &mut ifaces,
+                handle_new_link,
+            ) {
+                eprintln!("unable to list interfaces: {:?}", err);
+            };
+            if let Err(err) = enumerate_netlink(
+                &socket,
+                RtnlMessage::GetAddress(AddressMessage::default()),
+                &mut ifaces,
+                handle_new_addr,
+            ) {
+                eprintln!("unable to list addresses: {:?}", err);
+            }
+        }
         ifaces
     }
 
-    fn enumerate_netlink(socket: &Socket, msg: RtnlMessage, ifaces: &mut Vec<Interface>) {
-        let mut packet = NetlinkMessage::new(NetlinkHeader::default(), NetlinkPayload::from(msg));
-        packet.header.flags = NLM_F_DUMP | NLM_F_REQUEST;
-        packet.header.sequence_number = 1;
-        packet.finalize();
+    fn handle_new_link(ifaces: &mut Vec<Interface>, msg: RtnlMessage) -> io::Result<()> {
+        match msg {
+            RtnlMessage::NewLink(link_msg) => {
+                let mut interface: Interface = Interface {
+                    index: link_msg.header.index,
+                    name: String::new(),
+                    friendly_name: None,
+                    description: None,
+                    if_type: InterfaceType::try_from(link_msg.header.link_layer_type as u32)
+                        .unwrap_or(InterfaceType::Unknown),
+                    mac_addr: None,
+                    ipv4: Vec::new(),
+                    ipv6: Vec::new(),
+                    flags: link_msg.header.flags,
+                    transmit_speed: None,
+                    receive_speed: None,
+                    gateway: None,
+                };
 
-        let mut buf = vec![0; packet.header.length as usize];
-
-        // TODO: gracefully handle error
-        assert!(buf.len() == packet.buffer_len());
-        packet.serialize(&mut buf[..]);
-
-        socket.send(&buf[..], 0).unwrap();
-
-        let mut receive_buffer = vec![0; 4096];
-        let mut offset = 0;
-
-        loop {
-            let size = socket.recv(&mut &mut receive_buffer[..], 0).unwrap();
-
-            loop {
-                let bytes = &receive_buffer[offset..];
-                let rx_packet: NetlinkMessage<RtnlMessage> =
-                    NetlinkMessage::deserialize(bytes).unwrap();
-
-                match rx_packet.payload {
-                    NetlinkPayload::Done => {
-                        return;
-                    }
-                    NetlinkPayload::Error(err) => {
-                        eprintln!("Error: {:?}", err);
-                        return;
-                    }
-                    NetlinkPayload::InnerMessage(msg) => {
-                        match msg {
-                            RtnlMessage::NewLink(link_msg) => {
-                                let mut interface: Interface = Interface {
-                                    index: link_msg.header.index,
-                                    name: String::new(),
-                                    friendly_name: None,
-                                    description: None,
-                                    if_type: InterfaceType::try_from(
-                                        link_msg.header.link_layer_type as u32,
-                                    )
-                                    .unwrap_or(InterfaceType::Unknown),
-                                    mac_addr: None,
-                                    ipv4: Vec::new(),
-                                    ipv6: Vec::new(),
-                                    flags: link_msg.header.flags,
-                                    transmit_speed: None,
-                                    receive_speed: None,
-                                    gateway: None,
-                                };
-
-                                for nla in link_msg.nlas {
-                                    match nla {
-                                        LinkNla::IfName(name) => {
-                                            interface.name = name;
-                                        }
-                                        LinkNla::Address(addr) => {
-                                            match addr.len() {
-                                                6 => {
-                                                    interface.mac_addr = Some(MacAddr::new(
-                                                        addr.try_into().unwrap(),
-                                                    ));
-                                                }
-                                                4 => {
-                                                    let ip = Ipv4Addr::from(
-                                                        <[u8; 4]>::try_from(addr).unwrap(),
-                                                    );
-                                                    interface.ipv4.push(Ipv4Net::new_with_netmask(
-                                                        ip,
-                                                        Ipv4Addr::UNSPECIFIED,
-                                                    ));
-                                                }
-                                                _ => {
-                                                    // unclear what these would be
-                                                }
-                                            }
-                                        }
-                                        _ => {}
-                                    }
+                for nla in link_msg.nlas {
+                    match nla {
+                        LinkNla::IfName(name) => {
+                            interface.name = name;
+                        }
+                        LinkNla::Address(addr) => {
+                            match addr.len() {
+                                6 => {
+                                    interface.mac_addr =
+                                        Some(MacAddr::new(addr.try_into().unwrap()));
                                 }
-                                ifaces.push(interface);
-                            }
-                            RtnlMessage::NewAddress(addr_msg) => {
-                                if let Some(interface) =
-                                    ifaces.iter_mut().find(|i| i.index == addr_msg.header.index)
-                                {
-                                    for nla in addr_msg.nlas {
-                                        match nla {
-                                            AddressNla::Address(addr) => match addr.len() {
-                                                4 => {
-                                                    let ip = Ipv4Addr::from(
-                                                        <[u8; 4]>::try_from(addr).unwrap(),
-                                                    );
-                                                    interface.ipv4.push(Ipv4Net::new(
-                                                        ip,
-                                                        addr_msg.header.prefix_len,
-                                                    ));
-                                                }
-                                                16 => {
-                                                    let ip = Ipv6Addr::from(
-                                                        <[u8; 16]>::try_from(addr).unwrap(),
-                                                    );
-                                                    interface.ipv6.push(Ipv6Net::new(
-                                                        ip,
-                                                        addr_msg.header.prefix_len,
-                                                    ));
-                                                }
-                                                _ => {
-                                                    // what else?
-                                                }
-                                            },
-                                            _ => {}
-                                        }
-                                    }
-                                } else {
-                                    eprintln!(
-                                        "found unknown interface with index: {}",
-                                        addr_msg.header.index
-                                    );
+                                4 => {
+                                    let ip = Ipv4Addr::from(<[u8; 4]>::try_from(addr).unwrap());
+                                    interface
+                                        .ipv4
+                                        .push(Ipv4Net::new_with_netmask(ip, Ipv4Addr::UNSPECIFIED));
+                                }
+                                _ => {
+                                    // unclear what these would be
                                 }
                             }
+                        }
+                        _ => {}
+                    }
+                }
+                ifaces.push(interface);
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+
+    fn handle_new_addr(ifaces: &mut Vec<Interface>, msg: RtnlMessage) -> io::Result<()> {
+        match msg {
+            RtnlMessage::NewAddress(addr_msg) => {
+                if let Some(interface) =
+                    ifaces.iter_mut().find(|i| i.index == addr_msg.header.index)
+                {
+                    for nla in addr_msg.nlas {
+                        match nla {
+                            AddressNla::Address(addr) => match addr.len() {
+                                4 => {
+                                    let ip = Ipv4Addr::from(<[u8; 4]>::try_from(addr).unwrap());
+                                    interface
+                                        .ipv4
+                                        .push(Ipv4Net::new(ip, addr_msg.header.prefix_len));
+                                }
+                                16 => {
+                                    let ip = Ipv6Addr::from(<[u8; 16]>::try_from(addr).unwrap());
+                                    interface
+                                        .ipv6
+                                        .push(Ipv6Net::new(ip, addr_msg.header.prefix_len));
+                                }
+                                _ => {
+                                    // what else?
+                                }
+                            },
+                            _ => {}
+                        }
+                    }
+                } else {
+                    eprintln!(
+                        "found unknown interface with index: {}",
+                        addr_msg.header.index
+                    );
+                }
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+
+    struct NetlinkIter<'a> {
+        socket: &'a Socket,
+        /// Buffer for received data.
+        buf: Vec<u8>,
+        /// Size of the data available in `buf`.
+        size: usize,
+        /// Offset into the data currently in `buf`.
+        offset: usize,
+        /// Are we don iterating?
+        done: bool,
+    }
+
+    impl<'a> NetlinkIter<'a> {
+        fn new(socket: &'a Socket, msg: RtnlMessage) -> io::Result<Self> {
+            let mut packet =
+                NetlinkMessage::new(NetlinkHeader::default(), NetlinkPayload::from(msg));
+            packet.header.flags = NLM_F_DUMP | NLM_F_REQUEST;
+            packet.header.sequence_number = 1;
+            packet.finalize();
+
+            let mut buf = vec![0; packet.header.length as usize];
+            assert_eq!(buf.len(), packet.buffer_len());
+            packet.serialize(&mut buf[..]);
+            socket.send(&buf[..], 0)?;
+
+            Ok(NetlinkIter {
+                socket,
+                offset: 0,
+                size: 0,
+                buf: vec![0u8; 4096],
+                done: false,
+            })
+        }
+    }
+
+    impl<'a> Iterator for NetlinkIter<'a> {
+        type Item = io::Result<RtnlMessage>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if self.done {
+                return None;
+            }
+
+            while !self.done {
+                // Outer loop
+                if self.size == 0 {
+                    match self.socket.recv(&mut &mut self.buf[..], 0) {
+                        Ok(size) => {
+                            self.size = size;
+                            self.offset = 0;
+                        }
+                        Err(err) => {
+                            self.done = true;
+                            return Some(Err(err));
+                        }
+                    }
+                }
+
+                let bytes = &self.buf[self.offset..];
+                match NetlinkMessage::<RtnlMessage>::deserialize(bytes) {
+                    Ok(packet) => {
+                        self.offset += packet.header.length as usize;
+                        if packet.header.length == 0 || self.offset == self.size {
+                            // mark this message as fully read
+                            self.size = 0;
+                        }
+                        match packet.payload {
+                            NetlinkPayload::Done => {
+                                self.done = true;
+                                return None;
+                            }
+                            NetlinkPayload::Error(err) => {
+                                self.done = true;
+                                return Some(Err(io::Error::new(
+                                    io::ErrorKind::Other,
+                                    err.to_string(),
+                                )));
+                            }
+                            NetlinkPayload::InnerMessage(msg) => return Some(Ok(msg)),
                             _ => {
-                                // not expecting other messages
+                                continue;
                             }
                         }
                     }
-                    _ => {}
-                }
-                offset += rx_packet.header.length as usize;
-                if offset == size || rx_packet.header.length == 0 {
-                    offset = 0;
-                    break;
+                    Err(err) => {
+                        self.done = true;
+                        return Some(Err(io::Error::new(io::ErrorKind::Other, err.to_string())));
+                    }
                 }
             }
+
+            None
         }
+    }
+
+    fn enumerate_netlink<F>(
+        socket: &Socket,
+        msg: RtnlMessage,
+        ifaces: &mut Vec<Interface>,
+        cb: F,
+    ) -> io::Result<()>
+    where
+        F: Fn(&mut Vec<Interface>, RtnlMessage) -> io::Result<()>,
+    {
+        let iter = NetlinkIter::new(socket, msg)?;
+        for msg in iter {
+            let msg = msg?;
+            cb(ifaces, msg)?;
+        }
+
+        Ok(())
     }
 
     #[cfg(test)]

--- a/src/interface/android.rs
+++ b/src/interface/android.rs
@@ -1,10 +1,49 @@
-use crate::interface::Interface;
+use once_cell::sync::OnceCell;
 
-pub fn unix_interfaces() -> Vec<Interface> {
-    netlink::unix_interfaces()
+pub fn get_libc_ifaddrs() -> Option<(
+    unsafe extern "C" fn(*mut *mut libc::ifaddrs) -> libc::c_int,
+    unsafe extern "C" fn(*mut libc::ifaddrs),
+)> {
+    match (get_getifaddrs(), get_freeifaddrs()) {
+        (Some(a), Some(b)) => Some((a, b)),
+        _ => None,
+    }
 }
 
-mod netlink {
+fn load_symbol<T>(sym: &'static str) -> Option<T> {
+    const LIB_NAME: &str = "libc.so";
+
+    println!("loading symbol: {} from {}", sym, LIB_NAME);
+    match dlopen::raw::Library::open(LIB_NAME) {
+        Ok(lib) => match unsafe { lib.symbol::<T>(sym) } {
+            Ok(val) => Some(val),
+            Err(err) => {
+                eprintln!("failed to load symbol {} from {}: {:?}", sym, LIB_NAME, err);
+                None
+            }
+        },
+        Err(err) => {
+            eprintln!("failed to load {}: {:?}", LIB_NAME, err);
+            None
+        }
+    }
+}
+
+fn get_getifaddrs() -> Option<unsafe extern "C" fn(*mut *mut libc::ifaddrs) -> libc::c_int> {
+    static INSTANCE: OnceCell<
+        Option<unsafe extern "C" fn(*mut *mut libc::ifaddrs) -> libc::c_int>,
+    > = OnceCell::new();
+
+    *INSTANCE.get_or_init(|| load_symbol("getifaddrs"))
+}
+
+fn get_freeifaddrs() -> Option<unsafe extern "C" fn(*mut libc::ifaddrs)> {
+    static INSTANCE: OnceCell<Option<unsafe extern "C" fn(*mut libc::ifaddrs)>> = OnceCell::new();
+
+    *INSTANCE.get_or_init(|| load_symbol("freeifaddrs"))
+}
+
+pub mod netlink {
     //! Netlink based getifaddrs.
     //!
     //! Based on the logic found in https://git.musl-libc.org/cgit/musl/tree/src/network/getifaddrs.c

--- a/src/interface/android.rs
+++ b/src/interface/android.rs
@@ -1,5 +1,15 @@
 use once_cell::sync::OnceCell;
 
+pub fn get_libc_ifaddrs() -> Option<(
+    unsafe extern "C" fn(*mut *mut libc::ifaddrs) -> libc::c_int,
+    unsafe extern "C" fn(*mut libc::ifaddrs),
+)> {
+    match (get_getifaddrs(), get_freeifaddrs()) {
+        (Some(a), Some(b)) => Some((a, b)),
+        _ => None,
+    }
+}
+
 fn load_symbol<T>(sym: &'static str) -> Option<T> {
     const LIB_NAME: &str = "libc.so";
 
@@ -33,32 +43,191 @@ fn get_freeifaddrs() -> Option<unsafe extern "C" fn(*mut libc::ifaddrs)> {
     *INSTANCE.get_or_init(|| load_symbol("freeifaddrs"))
 }
 
-pub unsafe fn getifaddrs(ifap: *mut *mut libc::ifaddrs) -> libc::c_int {
-    // Android is complicated
+mod netlink {
+    //! Netlink based getifaddrs.
+    //!
+    //! Based on the logic found in https://git.musl-libc.org/cgit/musl/tree/src/network/getifaddrs.c
 
-    // API 24+ contains the getifaddrs and freeifaddrs functions but the NDK doesn't
-    // expose those functions in ifaddrs.h when the minimum supported SDK is lower than 24
-    // and therefore we need to load them manually.
-    if let Some(dyn_getifaddrs) = get_getifaddrs() {
-        return dyn_getifaddrs(ifap);
+    use netlink_packet_core::{
+        NetlinkHeader, NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST,
+    };
+    use netlink_packet_route::{
+        rtnl::address::nlas::Nla as AddressNla, rtnl::link::nlas::Nla as LinkNla, AddressMessage,
+        LinkMessage, RtnlMessage,
+    };
+    use netlink_sys::{protocols::NETLINK_ROUTE, Socket};
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    use crate::interface::{Interface, InterfaceType, Ipv4Net, Ipv6Net, MacAddr};
+
+    pub fn unix_interfaces() -> Vec<Interface> {
+        let socket = Socket::new(NETLINK_ROUTE).unwrap();
+
+        let mut ifaces = Vec::new();
+        enumerate_netlink(
+            &socket,
+            RtnlMessage::GetLink(LinkMessage::default()),
+            &mut ifaces,
+        );
+        enumerate_netlink(
+            &socket,
+            RtnlMessage::GetAddress(AddressMessage::default()),
+            &mut ifaces,
+        );
+
+        ifaces
     }
 
-    // If API < 24 (or we can't load libc for some other reason), we fallback to using netlink
-    netlink_getifaddrs(ifap)
-}
+    fn enumerate_netlink(socket: &Socket, msg: RtnlMessage, ifaces: &mut Vec<Interface>) {
+        let mut packet = NetlinkMessage::new(NetlinkHeader::default(), NetlinkPayload::from(msg));
+        packet.header.flags = NLM_F_DUMP | NLM_F_REQUEST;
+        packet.header.sequence_number = 1;
+        packet.finalize();
 
-pub unsafe fn freeifaddrs(ifa: *mut libc::ifaddrs) {
-    if let Some(dyn_freeifaddrs) = get_freeifaddrs() {
-        return dyn_freeifaddrs(ifa);
+        let mut buf = vec![0; packet.header.length as usize];
+
+        // TODO: gracefully handle error
+        assert!(buf.len() == packet.buffer_len());
+        packet.serialize(&mut buf[..]);
+
+        socket.send(&buf[..], 0).unwrap();
+
+        let mut receive_buffer = vec![0; 4096];
+        let mut offset = 0;
+
+        loop {
+            let size = socket.recv(&mut &mut receive_buffer[..], 0).unwrap();
+
+            loop {
+                let bytes = &receive_buffer[offset..];
+                let rx_packet: NetlinkMessage<RtnlMessage> =
+                    NetlinkMessage::deserialize(bytes).unwrap();
+
+                match rx_packet.payload {
+                    NetlinkPayload::Done => {
+                        return;
+                    }
+                    NetlinkPayload::Error(err) => {
+                        eprintln!("Error: {:?}", err);
+                        return;
+                    }
+                    NetlinkPayload::InnerMessage(msg) => {
+                        match msg {
+                            RtnlMessage::NewLink(link_msg) => {
+                                let mut interface: Interface = Interface {
+                                    index: link_msg.header.index,
+                                    name: String::new(),
+                                    friendly_name: None,
+                                    description: None,
+                                    if_type: InterfaceType::try_from(
+                                        link_msg.header.link_layer_type as u32,
+                                    )
+                                    .unwrap_or(InterfaceType::Unknown),
+                                    mac_addr: None,
+                                    ipv4: Vec::new(),
+                                    ipv6: Vec::new(),
+                                    flags: link_msg.header.flags,
+                                    transmit_speed: None,
+                                    receive_speed: None,
+                                    gateway: None,
+                                };
+
+                                for nla in link_msg.nlas {
+                                    match nla {
+                                        LinkNla::IfName(name) => {
+                                            interface.name = name;
+                                        }
+                                        LinkNla::Address(addr) => {
+                                            match addr.len() {
+                                                6 => {
+                                                    interface.mac_addr = Some(MacAddr::new(
+                                                        addr.try_into().unwrap(),
+                                                    ));
+                                                }
+                                                4 => {
+                                                    let ip = Ipv4Addr::from(
+                                                        <[u8; 4]>::try_from(addr).unwrap(),
+                                                    );
+                                                    interface.ipv4.push(Ipv4Net::new_with_netmask(
+                                                        ip,
+                                                        Ipv4Addr::UNSPECIFIED,
+                                                    ));
+                                                }
+                                                _ => {
+                                                    // unclear what these would be
+                                                }
+                                            }
+                                        }
+                                        _ => {}
+                                    }
+                                }
+                                ifaces.push(interface);
+                            }
+                            RtnlMessage::NewAddress(addr_msg) => {
+                                println!("NewAddress: {:?}", addr_msg);
+                                if let Some(interface) =
+                                    ifaces.iter_mut().find(|i| i.index == addr_msg.header.index)
+                                {
+                                    for nla in addr_msg.nlas {
+                                        match nla {
+                                            AddressNla::Address(addr) => match addr.len() {
+                                                4 => {
+                                                    let ip = Ipv4Addr::from(
+                                                        <[u8; 4]>::try_from(addr).unwrap(),
+                                                    );
+                                                    interface.ipv4.push(Ipv4Net::new(
+                                                        ip,
+                                                        addr_msg.header.prefix_len,
+                                                    ));
+                                                }
+                                                16 => {
+                                                    let ip = Ipv6Addr::from(
+                                                        <[u8; 16]>::try_from(addr).unwrap(),
+                                                    );
+                                                    interface.ipv6.push(Ipv6Net::new(
+                                                        ip,
+                                                        addr_msg.header.prefix_len,
+                                                    ));
+                                                }
+                                                _ => {
+                                                    // what else?
+                                                }
+                                            },
+                                            _ => {}
+                                        }
+                                    }
+                                } else {
+                                    eprintln!(
+                                        "found unknown interface with index: {}",
+                                        addr_msg.header.index
+                                    );
+                                }
+                            }
+                            _ => {
+                                // not expecting other messages
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+                offset += rx_packet.header.length as usize;
+                if offset == size || rx_packet.header.length == 0 {
+                    offset = 0;
+                    break;
+                }
+            }
+        }
     }
 
-    netlink_freeifaddrs(ifa)
-}
+    #[cfg(test)]
+    mod tests {
+        use super::*;
 
-unsafe fn netlink_getifaddrs(ifap: *mut *mut libc::ifaddrs) -> libc::c_int {
-    todo!()
-}
-
-unsafe fn netlink_freeifaddrs(ifa: *mut libc::ifaddrs) {
-    todo!()
+        #[test]
+        fn test_netlink_ifaddrs() {
+            let interfaces = unix_interfaces();
+            dbg!(&interfaces);
+            assert!(!interfaces.is_empty());
+        }
+    }
 }

--- a/src/interface/linux.rs
+++ b/src/interface/linux.rs
@@ -1,6 +1,6 @@
+use crate::interface::InterfaceType;
 use std::convert::TryFrom;
 use std::fs::read_to_string;
-use crate::interface::InterfaceType;
 
 pub fn get_interface_type(if_name: String) -> InterfaceType {
     let if_type_path: String = format!("/sys/class/net/{}/type", if_name);
@@ -11,16 +11,16 @@ pub fn get_interface_type(if_name: String) -> InterfaceType {
             match if_type_string.parse::<u32>() {
                 Ok(if_type) => {
                     return InterfaceType::try_from(if_type).unwrap_or(InterfaceType::Unknown);
-                },
+                }
                 Err(_) => {
                     return InterfaceType::Unknown;
                 }
             }
-        },
+        }
         Err(_) => {
             return InterfaceType::Unknown;
         }
-    };   
+    };
 }
 
 pub fn get_interface_speed(if_name: String) -> Option<u64> {
@@ -33,14 +33,14 @@ pub fn get_interface_speed(if_name: String) -> Option<u64> {
                 Ok(if_speed) => {
                     // Convert Mbps to bps
                     return Some(if_speed * 1000000);
-                },
+                }
                 Err(_) => {
                     return None;
                 }
             }
-        },
+        }
         Err(_) => {
             return None;
         }
-    };   
+    };
 }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -4,9 +4,25 @@ pub use self::shared::*;
 mod types;
 pub use self::types::*;
 
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "openbsd", target_os = "freebsd", target_os = "netbsd", target_os = "ios", target_os = "android"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "openbsd",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "ios",
+    target_os = "android"
+))]
 mod unix;
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "openbsd", target_os = "freebsd", target_os = "netbsd", target_os = "ios", target_os = "android"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "openbsd",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "ios",
+    target_os = "android"
+))]
 use self::unix::*;
 
 #[cfg(target_os = "windows")]
@@ -17,12 +33,15 @@ use self::windows::*;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux;
 
+#[cfg(target_os = "android")]
+mod android;
+
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod macos;
 
-use std::net::IpAddr;
+use crate::gateway::Gateway;
 use crate::ip::{Ipv4Net, Ipv6Net};
-use crate::gateway::{Gateway};
+use std::net::IpAddr;
 
 /// Structure of MAC address
 #[derive(Clone, Debug)]
@@ -31,24 +50,29 @@ pub struct MacAddr(u8, u8, u8, u8, u8, u8);
 impl MacAddr {
     /// Construct a new MacAddr instance from the given octets
     pub fn new(octets: [u8; 6]) -> MacAddr {
-        MacAddr(octets[0], octets[1], octets[2], octets[3], octets[4], octets[5])
+        MacAddr(
+            octets[0], octets[1], octets[2], octets[3], octets[4], octets[5],
+        )
     }
     /// Returns an array of MAC address octets
     pub fn octets(&self) -> [u8; 6] {
-        [self.0,self.1,self.2,self.3,self.4,self.5]
+        [self.0, self.1, self.2, self.3, self.4, self.5]
     }
     /// Return a formatted string of MAC address
     pub fn address(&self) -> String {
-        format!("{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}", self.0,self.1,self.2,self.3,self.4,self.5)
+        format!(
+            "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+            self.0, self.1, self.2, self.3, self.4, self.5
+        )
     }
     /// Construct an all-zero MacAddr instance
     pub fn zero() -> MacAddr {
-        MacAddr(0,0,0,0,0,0)
+        MacAddr(0, 0, 0, 0, 0, 0)
     }
     /// Construct a new MacAddr instance from a colon-separated string of hex format
     pub fn from_hex_format(hex_mac_addr: &str) -> MacAddr {
         if hex_mac_addr.len() != 17 {
-            return MacAddr(0,0,0,0,0,0)
+            return MacAddr(0, 0, 0, 0, 0, 0);
         }
         let fields: Vec<&str> = hex_mac_addr.split(":").collect();
         let o1: u8 = u8::from_str_radix(&fields[0], 0x10).unwrap_or(0);
@@ -63,8 +87,12 @@ impl MacAddr {
 
 impl std::fmt::Display for MacAddr {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        let _ = write!(f,"{:<02x}:{:<02x}:{:<02x}:{:<02x}:{:<02x}:{:<02x}",self.0,self.1,self.2,self.3,self.4,self.5);
-        Ok(())   
+        let _ = write!(
+            f,
+            "{:<02x}:{:<02x}:{:<02x}:{:<02x}:{:<02x}:{:<02x}",
+            self.0, self.1, self.2, self.3, self.4, self.5
+        );
+        Ok(())
     }
 }
 
@@ -76,7 +104,7 @@ pub struct Interface {
     /// Name of network interface
     pub name: String,
     /// Friendly Name of network interface
-    pub friendly_name : Option<String>,
+    pub friendly_name: Option<String>,
     /// Description of the network interface
     pub description: Option<String>,
     /// Interface Type
@@ -99,7 +127,7 @@ pub struct Interface {
 
 /// Get default Network Interface
 pub fn get_default_interface() -> Result<Interface, String> {
-    let local_ip: IpAddr = match get_local_ipaddr(){
+    let local_ip: IpAddr = match get_local_ipaddr() {
         Some(local_ip) => local_ip,
         None => return Err(String::from("Local IP address not found")),
     };
@@ -110,12 +138,12 @@ pub fn get_default_interface() -> Result<Interface, String> {
                 if iface.ipv4.iter().any(|x| x.addr == local_ipv4) {
                     return Ok(iface);
                 }
-            },
+            }
             IpAddr::V6(local_ipv6) => {
                 if iface.ipv6.iter().any(|x| x.addr == local_ipv6) {
                     return Ok(iface);
                 }
-            },
+            }
         }
     }
     Err(String::from("Default Interface not found"))
@@ -123,7 +151,7 @@ pub fn get_default_interface() -> Result<Interface, String> {
 
 /// Get default Network Interface index
 pub fn get_default_interface_index() -> Option<u32> {
-    let local_ip: IpAddr = match get_local_ipaddr(){
+    let local_ip: IpAddr = match get_local_ipaddr() {
         Some(local_ip) => local_ip,
         None => return None,
     };
@@ -134,12 +162,12 @@ pub fn get_default_interface_index() -> Option<u32> {
                 if iface.ipv4.iter().any(|x| x.addr == local_ipv4) {
                     return Some(iface.index);
                 }
-            },
+            }
             IpAddr::V6(local_ipv6) => {
                 if iface.ipv6.iter().any(|x| x.addr == local_ipv6) {
                     return Some(iface.index);
                 }
-            },
+            }
         }
     }
     None
@@ -147,7 +175,7 @@ pub fn get_default_interface_index() -> Option<u32> {
 
 /// Get default Network Interface name
 pub fn get_default_interface_name() -> Option<String> {
-    let local_ip: IpAddr = match get_local_ipaddr(){
+    let local_ip: IpAddr = match get_local_ipaddr() {
         Some(local_ip) => local_ip,
         None => return None,
     };
@@ -158,12 +186,12 @@ pub fn get_default_interface_name() -> Option<String> {
                 if iface.ipv4.iter().any(|x| x.addr == local_ipv4) {
                     return Some(iface.name);
                 }
-            },
+            }
             IpAddr::V6(local_ipv6) => {
                 if iface.ipv6.iter().any(|x| x.addr == local_ipv6) {
                     return Some(iface.name);
                 }
-            },
+            }
         }
     }
     None

--- a/src/interface/unix.rs
+++ b/src/interface/unix.rs
@@ -149,7 +149,7 @@ pub(super) fn sockaddr_to_network_addr(
             let addr =
                 sys::sockaddr_to_addr(mem::transmute(sa), mem::size_of::<libc::sockaddr_storage>());
 
-            match dbg!(addr) {
+            match addr {
                 Ok(SocketAddr::V4(sa)) => (None, Some(IpAddr::V4(*sa.ip()))),
                 Ok(SocketAddr::V6(sa)) => (None, Some(IpAddr::V6(*sa.ip()))),
                 Err(_) => (None, None),


### PR DESCRIPTION
Unfortunately the default ways are not as easily used on different Android versions. 

This implements two different versions for doing this on Android, which should allow supporting Android back to NDK API version 16 (the one that I need currently) up to today. 

The first approach is to use dlopen to load libc and use `getifaddrs` which should work on API 24 and up. The headers are unfortunately not exposed, which is why this workaround is needed. 
For all other versions where the symbols are not available, a backup using `netlink` is implemented. 

This is currently still being tested, which is why I am opening this as a draft, for feedback if this would be merged once it is confirmed to be working.

(Sorry for the whitespace changes, I ran `cargo fmt` on the files I was working on)
