### PR TITLE
Fix android build and add more CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,53 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
+
       - name: Run rustfmt
         run: cargo fmt --all --check
+
+  check:
+    name: Check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
+
+      - uses: swatinem/rust-cache@v2
+
+      - name: Run cargo check
+        run: cargo check
+
+  cross:
+    name: Cross compile
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - i686-unknown-linux-gnu
+          - armv7-linux-androideabi
+          - aarch64-linux-android
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Install Rust Toolchain
+        run: rustup toolchain install stable --profile minimal --no-self-update
+
+      - uses: swatinem/rust-cache@v2
+
+      - name: Install cross
+        run: cargo install cross
+
+      - name: Rust check
+        run: cross check --target ${{ matrix.target }}

--- a/src/interface/android.rs
+++ b/src/interface/android.rs
@@ -13,7 +13,7 @@ pub fn get_libc_ifaddrs() -> Option<(
 fn load_symbol<T>(sym: &'static str) -> Option<T> {
     const LIB_NAME: &str = "libc.so";
 
-    match dlopen::raw::Library::open(LIB_NAME) {
+    match dlopen2::raw::Library::open(LIB_NAME) {
         Ok(lib) => match unsafe { lib.symbol::<T>(sym) } {
             Ok(val) => Some(val),
             Err(err) => {


### PR DESCRIPTION
Thank you very much for making the 0.14 release so quickly!  But it seems I must apologise as I messed up the android support earlier and it is still broken in the release.

This fixes it up again, and adds a bunch more CI that should make sure this doesn't happen again.  The CI does not yet run tests, they do not pass on all platforms currently.  But it does take some good steps in the right direction.