### PR TITLE
fix(ci): Use rust 1.68 for android compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Install Rust Toolchain
-        run: rustup toolchain install stable --profile minimal --no-self-update
+        # See https://github.com/cross-rs/cross/issues/1222 for when
+        # stable can be used instead of 1.67 again.
+        run: rustup toolchain install 1.67 --profile minimal --no-self-update
 
       - uses: swatinem/rust-cache@v2
 


### PR DESCRIPTION
I noticed you had a CI failure on #28, this seems to fix it.  I didn't dig deep into this though, more copy-pasted this from another CI thing I managed to get to work by downgrading the rust version. and it seems to work, so probably a similar problem.