### PR TITLE
ref(deps): Only request basic features of dlopen2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ libc = "0.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
 # DL Open
-dlopen2 = "0.4"
+dlopen2 = { version = "0.4", default-features = false }
 once_cell = "1"
 # netlink
 netlink-packet-core = "0.5"


### PR DESCRIPTION
The code doesn't use any of the advanced features, so remove some dependencies.

This doesn't need to trigger a release, it's just some maintenance.