### PR TITLE
Implement optional `serde` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ license = "MIT"
 
 [dependencies]
 libc = "0.2"
+serde = { version = "1", features = ["derive"], optional = true }
+
+[features]
+serde = ["dep:serde"]
 
 [target.'cfg(target_os = "android")'.dependencies]
 # DL Open

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -7,11 +7,15 @@ pub(crate) mod macos;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub(crate) mod linux;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use crate::interface::{self, Interface, MacAddr};
 use std::net::{IpAddr, Ipv4Addr};
 
 /// Structure of default Gateway information
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Gateway {
     /// MAC address of Gateway
     pub mac_addr: MacAddr,

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -30,6 +30,9 @@ mod windows;
 #[cfg(target_os = "windows")]
 use self::windows::*;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 #[cfg(any(target_os = "linux", target_os = "android"))]
 mod linux;
 
@@ -47,6 +50,7 @@ use crate::sys;
 
 /// Structure of MAC address
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MacAddr(u8, u8, u8, u8, u8, u8);
 
 impl MacAddr {
@@ -100,6 +104,7 @@ impl std::fmt::Display for MacAddr {
 
 /// Structure of Network Interface information
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Interface {
     /// Index of network interface
     pub index: u32,

--- a/src/interface/types.rs
+++ b/src/interface/types.rs
@@ -1,7 +1,11 @@
 use std::convert::TryFrom;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Type of Network Interface
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum InterfaceType {
     /// Unknown interface type
     Unknown,

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -1,7 +1,11 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Structure of IPv4 Network
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Ipv4Net {
     /// IPv4 Address
     pub addr: Ipv4Addr,
@@ -32,6 +36,7 @@ impl Ipv4Net {
 
 /// Structure of IPv6 Network
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Ipv6Net {
     /// IPv6 Address
     pub addr: Ipv6Addr,


### PR DESCRIPTION
This PR implement optional support for `serde`. Users should be able to add the `serde` feature when adding this crate to their `Cargo.toml` file and get the benefits of `serde` for all public types.