### PR TITLE
#55 Rebranding to netdev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "default-net"
-version = "0.22.0"
-authors = ["shellrow <shellrow@protonmail.com>"]
+name = "netdev"
+version = "0.23.0"
+authors = ["shellrow <shellrow@foctet.com>"]
 edition = "2021"
-description = "Cross-platform library for network interface and gateway"
-repository = "https://github.com/shellrow/default-net"
+description = "Cross-platform library for network interface"
+repository = "https://github.com/shellrow/netdev"
 readme = "README.md"
 keywords = ["network"]
 categories = ["network-programming"]
@@ -31,7 +31,7 @@ version = "0.48.0"
 features = ["Win32_Foundation","Win32_NetworkManagement_IpHelper", "Win32_Networking_WinSock", "Win32_NetworkManagement_Ndis"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-system-configuration = "0.5.1"
+system-configuration = "0.6"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 shellrow
+Copyright (c) 2024 shellrow
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,20 +1,26 @@
-[crates-badge]: https://img.shields.io/crates/v/default-net.svg
-[crates-url]: https://crates.io/crates/default-net
-[license-badge]: https://img.shields.io/crates/l/default-net.svg
-[examples-url]: https://github.com/shellrow/default-net/tree/main/examples
+[crates-badge]: https://img.shields.io/crates/v/netdev.svg
+[crates-url]: https://crates.io/crates/netdev
+[license-badge]: https://img.shields.io/crates/l/netdev.svg
+[examples-url]: https://github.com/shellrow/netdev/tree/main/examples
+[doc-url]: https://docs.rs/netdev/latest/netdev
+[doc-interface-url]: https://docs.rs/netdev/latest/netdev/interface/struct.Interface.html
 [netdev-github-url]: https://github.com/shellrow/netdev
-[netdev-crates-io-url]: https://crates.io/crates/netdev
+[default-net-github-url]: https://github.com/shellrow/default-net
+[default-net-crates-io-url]: https://crates.io/crates/default-net
 
-# Notice
-- This project has been rebranded to `netdev` and repository has been moved to the https://github.com/shellrow/netdev 
-- This crate has been moved to [netdev][netdev-crates-io-url] from `0.23`
-
-# default-net [![Crates.io][crates-badge]][crates-url] ![License][license-badge]
+# netdev [![Crates.io][crates-badge]][crates-url] ![License][license-badge]
   
-`default-net` provides a cross-platform API for network interface and gateway.
+`netdev` provides a cross-platform API for network interface.
 
-- Get default Network Interface and Gateway information
-- Get list of available Network Interfaces
+## Key Features
+- Get list of available network interfaces
+- Get default network interface
+- Access additional information related to network interface
+
+Please refer to the [Interface][doc-interface-url] struct documentation for detail.
+
+## Notice
+This project was rebranded from [default-net][default-net-crates-io-url] by the author myself for future expansion, continuation, and better alignment with naming conventions.
 
 ## Supported platform
 - Linux
@@ -22,13 +28,13 @@
 - Windows
 
 ## Usage
-Add `default-net` to your dependencies  
+Add `netdev` to your dependencies  
 ```toml:Cargo.toml
 [dependencies]
-default-net = "0.22"
+netdev = "0.23"
 ```
 
-For more details, see [examples][examples-url] or doc.  
+For more details, see [examples][examples-url] or [doc][doc-url].  
 
 ## Tested on
 - Linux
@@ -45,6 +51,6 @@ For more details, see [examples][examples-url] or doc.
     - 13.4.1
     - 11.6
 - Windows 
-    - 11 Pro 22H2 22621.1848
-    - 11 21H2 22000.493
+    - 11 Pro 22H2 22621.3155
+    - 11 22H2 22621.3155
     - 10 21H2 19044.1586

--- a/examples/default_gateway.rs
+++ b/examples/default_gateway.rs
@@ -1,11 +1,12 @@
 // This example shows how to get the default gateway and its properties.
 
 fn main() {
-    match default_net::get_default_gateway() {
+    match netdev::get_default_gateway() {
         Ok(gateway) => {
             println!("Default Gateway");
             println!("\tMAC Address: {}", gateway.mac_addr);
-            println!("\tIP Address: {}", gateway.ip_addr);
+            println!("\tIPv4: {:?}", gateway.ipv4);
+            println!("\tIPv6: {:?}", gateway.ipv6);
         }
         Err(e) => {
             println!("Error: {}", e);

--- a/examples/default_interface.rs
+++ b/examples/default_interface.rs
@@ -1,7 +1,7 @@
 // This example shows how to get the default network interface and its properties.
 
 fn main() {
-    match default_net::get_default_interface() {
+    match netdev::get_default_interface() {
         Ok(interface) => {
             println!("Default Interface:");
             println!("\tIndex: {}", interface.index);
@@ -28,10 +28,13 @@ fn main() {
             if let Some(gateway) = interface.gateway {
                 println!("Default Gateway");
                 println!("\tMAC Address: {}", gateway.mac_addr);
-                println!("\tIP Address: {}", gateway.ip_addr);
+                println!("\tIPv4: {:?}", gateway.ipv4);
+                println!("\tIPv6: {:?}", gateway.ipv6);
             } else {
                 println!("Default Gateway: (Not found)");
             }
+            println!("DNS Servers: {:?}", interface.dns_servers);
+            println!("Default: {}", interface.default);
         }
         Err(e) => {
             println!("Error: {}", e);

--- a/examples/list_interfaces.rs
+++ b/examples/list_interfaces.rs
@@ -1,7 +1,7 @@
 // This example shows all interfaces and their properties.
 
 fn main() {
-    let interfaces = default_net::get_interfaces();
+    let interfaces = netdev::get_interfaces();
     for interface in interfaces {
         println!("Interface:");
         println!("\tIndex: {}", interface.index);
@@ -28,10 +28,13 @@ fn main() {
         if let Some(gateway) = interface.gateway {
             println!("Gateway");
             println!("\tMAC Address: {}", gateway.mac_addr);
-            println!("\tIP Address: {}", gateway.ip_addr);
+            println!("\tIPv4 Address: {:?}", gateway.ipv4);
+            println!("\tIPv6 Address: {:?}", gateway.ipv6);
         } else {
             println!("Gateway: (Not found)");
         }
+        println!("DNS Servers: {:?}", interface.dns_servers);
+        println!("Default: {}", interface.default);
         println!();
     }
 }

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -1,6 +1,6 @@
 // This example shows how to use serde feature to serialize the default network interface to JSON.
 fn main() {
-    match default_net::get_default_interface() {
+    match netdev::get_default_interface() {
         Ok(interface) => match serde_json::to_string_pretty(&interface) {
             Ok(json) => {
                 println!("{}", json);

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,0 +1,28 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::mac::MacAddr;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+/// Structure of NetworkDevice information
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct NetworkDevice {
+    /// MAC address of the device
+    pub mac_addr: MacAddr,
+    /// List of IPv4 address of the device
+    pub ipv4: Vec<Ipv4Addr>,
+    /// List of IPv6 address of the device
+    pub ipv6: Vec<Ipv6Addr>,
+}
+
+impl NetworkDevice {
+    /// Construct a new NetworkDevice instance
+    pub fn new() -> NetworkDevice {
+        NetworkDevice {
+            mac_addr: MacAddr::zero(),
+            ipv4: Vec::new(),
+            ipv6: Vec::new(),
+        }
+    }
+}

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -7,35 +7,12 @@ pub(crate) mod macos;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub(crate) mod linux;
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
+use crate::device::NetworkDevice;
 use crate::interface::{self, Interface};
-use crate::mac::MacAddr;
-use std::net::{IpAddr, Ipv4Addr};
-
-/// Structure of default Gateway information
-#[derive(Clone, Eq, PartialEq, Hash, Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct Gateway {
-    /// MAC address of Gateway
-    pub mac_addr: MacAddr,
-    /// IP address of Gateway
-    pub ip_addr: IpAddr,
-}
-
-impl Gateway {
-    /// Construct a new Gateway instance
-    pub fn new() -> Gateway {
-        Gateway {
-            mac_addr: MacAddr::zero(),
-            ip_addr: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-        }
-    }
-}
+use std::net::IpAddr;
 
 /// Get default Gateway
-pub fn get_default_gateway() -> Result<Gateway, String> {
+pub fn get_default_gateway() -> Result<NetworkDevice, String> {
     let local_ip: IpAddr = match interface::get_local_ipaddr() {
         Some(local_ip) => local_ip,
         None => return Err(String::from("Local IP address not found")),

--- a/src/gateway/unix.rs
+++ b/src/gateway/unix.rs
@@ -1,10 +1,10 @@
-use super::Gateway;
+use crate::device::NetworkDevice;
 use crate::socket;
 use std::time::{Duration, Instant};
 
 const TIMEOUT: u64 = 3000;
 
-pub fn get_default_gateway(interface_name: String) -> Result<Gateway, String> {
+pub fn get_default_gateway(interface_name: String) -> Result<NetworkDevice, String> {
     let timeout = Duration::from_millis(TIMEOUT);
     let start_time = Instant::now();
     let config = socket::Config {

--- a/src/interface/android.rs
+++ b/src/interface/android.rs
@@ -101,6 +101,8 @@ pub mod netlink {
                     transmit_speed: None,
                     receive_speed: None,
                     gateway: None,
+                    dns_servers: Vec::new(),
+                    default: false,
                 };
 
                 for nla in link_msg.nlas {

--- a/src/interface/linux.rs
+++ b/src/interface/linux.rs
@@ -1,6 +1,9 @@
 use crate::interface::InterfaceType;
 use std::convert::TryFrom;
 use std::fs::read_to_string;
+use std::net::IpAddr;
+
+const PATH_RESOLV_CONF: &str = "/etc/resolv.conf";
 
 pub fn get_interface_type(if_name: String) -> InterfaceType {
     let if_type_path: String = format!("/sys/class/net/{}/type", if_name);
@@ -43,4 +46,32 @@ pub fn get_interface_speed(if_name: String) -> Option<u64> {
             return None;
         }
     };
+}
+
+pub fn get_system_dns_conf() -> Vec<IpAddr> {
+    let r = read_to_string(PATH_RESOLV_CONF);
+    match r {
+        Ok(content) => {
+            let conf_lines: Vec<&str> = content.trim().split("\n").collect();
+            let mut dns_servers = Vec::new();
+            for line in conf_lines {
+                let fields: Vec<&str> = line.split_whitespace().collect();
+                if fields.len() >= 2 {
+                    // field [0]: Configuration type (e.g., "nameserver", "domain", "search")
+                    // field [1]: Corresponding value (e.g., IP address, domain name)
+                    if fields[0] == "nameserver" {
+                        if let Ok(ip) = fields[1].parse::<IpAddr>() {
+                            dns_servers.push(ip);
+                        } else {
+                            eprintln!("Invalid IP address format: {}", fields[1]);
+                        }
+                    }
+                }
+            }
+            dns_servers
+        }
+        Err(_) => {
+            return Vec::new();
+        }
+    }
 }

--- a/src/interface/macos.rs
+++ b/src/interface/macos.rs
@@ -1,18 +1,29 @@
 use crate::interface::InterfaceType;
-use std::collections::HashMap;
+use std::fs::read_to_string;
+use std::{collections::HashMap, net::IpAddr};
 use system_configuration::network_configuration;
+
+const PATH_RESOLV_CONF: &str = "/etc/resolv.conf";
 
 fn get_if_type_from_id(type_id: String) -> InterfaceType {
     match type_id.as_str() {
         "Ethernet" => InterfaceType::Ethernet,
         "IEEE80211" => InterfaceType::Wireless80211,
         "PPP" => InterfaceType::Ppp,
+        "Bridge" => InterfaceType::Bridge,
         _ => InterfaceType::Unknown,
     }
 }
 
-pub fn get_if_type_map() -> HashMap<String, InterfaceType> {
-    let mut map: HashMap<String, InterfaceType> = HashMap::new();
+#[derive(Debug)]
+pub struct SCInterface {
+    pub name: String,
+    pub friendly_name: Option<String>,
+    pub interface_type: InterfaceType,
+}
+
+pub fn get_if_type_map() -> HashMap<String, SCInterface> {
+    let mut map: HashMap<String, SCInterface> = HashMap::new();
     let interfaces = network_configuration::get_interfaces();
     for interface in &interfaces {
         let if_name: String = if let Some(bsd_name) = interface.bsd_name() {
@@ -25,7 +36,45 @@ pub fn get_if_type_map() -> HashMap<String, InterfaceType> {
         } else {
             continue;
         };
-        map.insert(if_name, get_if_type_from_id(type_id));
+        let friendly_name: Option<String> = if let Some(name) = interface.display_name() {
+            Some(name.to_string())
+        } else {
+            None
+        };
+        let sc_if = SCInterface {
+            name: if_name.clone(),
+            friendly_name: friendly_name,
+            interface_type: get_if_type_from_id(type_id),
+        };
+        map.insert(if_name, sc_if);
     }
     return map;
+}
+
+pub fn get_system_dns_conf() -> Vec<IpAddr> {
+    let r = read_to_string(PATH_RESOLV_CONF);
+    match r {
+        Ok(content) => {
+            let conf_lines: Vec<&str> = content.trim().split("\n").collect();
+            let mut dns_servers = Vec::new();
+            for line in conf_lines {
+                let fields: Vec<&str> = line.split_whitespace().collect();
+                if fields.len() >= 2 {
+                    // field [0]: Configuration type (e.g., "nameserver", "domain", "search")
+                    // field [1]: Corresponding value (e.g., IP address, domain name)
+                    if fields[0] == "nameserver" {
+                        if let Ok(ip) = fields[1].parse::<IpAddr>() {
+                            dns_servers.push(ip);
+                        } else {
+                            eprintln!("Invalid IP address format: {}", fields[1]);
+                        }
+                    }
+                }
+            }
+            dns_servers
+        }
+        Err(_) => {
+            return Vec::new();
+        }
+    }
 }

--- a/src/interface/types.rs
+++ b/src/interface/types.rs
@@ -63,6 +63,8 @@ pub enum InterfaceType {
     Wwanpp,
     /// The network interface using a mobile broadband interface for CDMA-based devices
     Wwanpp2,
+    /// Transparent bridge interface
+    Bridge,
 }
 
 impl InterfaceType {
@@ -98,6 +100,7 @@ impl InterfaceType {
             InterfaceType::Wman => 237,
             InterfaceType::Wwanpp => 243,
             InterfaceType::Wwanpp2 => 244,
+            _ => u32::MAX,
         }
     }
     /// Returns OS-specific value of InterfaceType
@@ -159,6 +162,7 @@ impl InterfaceType {
             InterfaceType::Tunnel => String::from("Tunnel"),
             InterfaceType::MultiRateSymmetricDsl => String::from("Multi-Rate Symmetric DSL"),
             InterfaceType::HighPerformanceSerialBus => String::from("High Performance Serial Bus"),
+            InterfaceType::Bridge => String::from("Bridge"),
             InterfaceType::Wman => String::from("WMAN"),
             InterfaceType::Wwanpp => String::from("WWANPP"),
             InterfaceType::Wwanpp2 => String::from("WWANPP2"),

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -74,6 +74,19 @@ impl IpNet {
             IpNet::V6(ref a) => IpAddr::V6(a.broadcast()),
         }
     }
+    /// Checks if the IP Address is in the network.
+    pub fn contains(&self, ip: IpAddr) -> bool {
+        match *self {
+            IpNet::V4(ref a) => match ip {
+                IpAddr::V4(ip) => a.contains(ip),
+                IpAddr::V6(_) => false,
+            },
+            IpNet::V6(ref a) => match ip {
+                IpAddr::V4(_) => false,
+                IpAddr::V6(ip) => a.contains(ip),
+            },
+        }
+    }
 }
 
 impl From<Ipv4Net> for IpNet {
@@ -157,6 +170,10 @@ impl Ipv4Net {
     /// Returns the broadcast address.
     pub fn broadcast(&self) -> Ipv4Addr {
         Ipv4Addr::from(u32::from(self.addr) | self.hostmask_u32())
+    }
+    /// Checks if the IP Address is in the network.
+    pub fn contains(&self, ip: Ipv4Addr) -> bool {
+        self.network() == Ipv4Addr::from(u32::from(ip) & self.netmask_u32())
     }
 }
 
@@ -242,6 +259,11 @@ impl Ipv6Net {
     /// Returns the broadcast address.
     pub fn broadcast(&self) -> Ipv6Addr {
         (u128::from(self.addr) | self.hostmask_u128()).into()
+    }
+    /// Checks if the IP Address is in the network.
+    pub fn contains(&self, ip: Ipv6Addr) -> bool {
+        let ipv6_network: Ipv6Addr = (u128::from(ip) & self.netmask_u128()).into();
+        self.network() == ipv6_network
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,14 +9,15 @@ mod bpf;
 #[cfg(any(target_os = "openbsd", target_os = "freebsd", target_os = "netbsd"))]
 mod socket;
 
+pub mod device;
 pub mod gateway;
 pub mod interface;
 pub mod ip;
 pub mod mac;
 mod sys;
 
+pub use device::NetworkDevice;
 pub use gateway::get_default_gateway;
-pub use gateway::Gateway;
 pub use interface::get_default_interface;
 pub use interface::get_interfaces;
 pub use interface::Interface;

--- a/src/socket/unix.rs
+++ b/src/socket/unix.rs
@@ -15,7 +15,7 @@ pub enum ChannelType {
 
 #[non_exhaustive]
 pub enum Channel {
-    Ethernet(Box<dyn DataLinkSender>, Box<dyn DataLinkReceiver>),
+    Ethernet(Box<dyn FrameSender>, Box<dyn FrameReceiver>),
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -55,7 +55,7 @@ pub fn channel(interface_name: String, configuration: Config) -> io::Result<Chan
     bpf::channel(interface_name, (&configuration).into())
 }
 
-pub trait DataLinkSender: Send {
+pub trait FrameSender: Send {
     fn build_and_send(
         &mut self,
         num_packets: usize,
@@ -66,6 +66,6 @@ pub trait DataLinkSender: Send {
     fn send_to(&mut self, packet: &[u8], dst: Option<Interface>) -> Option<io::Result<()>>;
 }
 
-pub trait DataLinkReceiver: Send {
+pub trait FrameReceiver: Send {
     fn next(&mut self) -> io::Result<&[u8]>;
 }


### PR DESCRIPTION
- Rebranding to `netdev` ( from `v0.23.0`)
- Support IPv6 gateway (route)
- Support DNS Server
- Support friendly_name for macOS
- Replace `Gateway` to `NetworkDevice`
- Fix MacOS bug in get route info
- Some refactoring