### PR TITLE
Upgrade to netlink-packet-route@0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ dlopen2 = { version = "0.5", default-features = false }
 once_cell = "1"
 # netlink
 netlink-packet-core = "0.7"
-netlink-packet-route = "0.17"
+netlink-packet-route = "0.21"
 netlink-sys = "0.8"
 
 [target.'cfg(windows)'.dependencies.windows-sys]


### PR DESCRIPTION
This PR upgrades `netlink-packet-route` to the latest (0.21). 

The code compiles for `aarch64-linux-android` but I have not done any testing on actual android device. The assumption that everything stays the same except the newer `netlink-packet-route` has much nicer interface to work with.

If you accept that PR, please consider making a new release as I'd be happy to trim the older `netlink-packet-route` from my cargo tree. Thank you.