### PR TITLE
Add support for detecting IPv6 scope IDs, plus some cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,12 @@ jobs:
       - name: Install Rust Toolchain
         run: rustup toolchain install stable --profile minimal --no-self-update
 
+      - uses: swatinem/rust-cache@v2
+
       - name: Install cross
         run: cargo install cross
 
-      - name: Rust check
-        run: cross check --target ${{ matrix.target }}
+      - name: Cross Compile Check
+        run: |
+          export CARGO_TARGET_DIR=target/build/${{ matrix.target }}
+          cross check --target ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,6 @@ jobs:
       - name: Install Rust Toolchain
         run: rustup toolchain install stable --profile minimal --no-self-update
 
-      - uses: swatinem/rust-cache@v2
-
       - name: Install cross
         run: cargo install cross
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
 
       - uses: swatinem/rust-cache@v2
 
+      - name: "Display network interfaces on machine (for test failure debugging)"
+        run: cargo run --example list_interfaces
+
       - name: Run cargo build
         run: cargo build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
         run: rustup toolchain install stable --profile minimal --no-self-update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,11 @@ jobs:
 
       - uses: swatinem/rust-cache@v2
 
-      - name: Run cargo check
-        run: cargo check
+      - name: Run cargo build
+        run: cargo build
+
+      - name: Run cargo test
+        run: cargo test
 
   cross:
     name: Cross compile

--- a/examples/list_interfaces.rs
+++ b/examples/list_interfaces.rs
@@ -26,7 +26,12 @@ fn main() {
         println!("\tIPv4: {:?}", interface.ipv4);
 
         // Print the IPv6 addresses with the scope ID after them as a suffix
-        let ipv6_strs: Vec<String> = interface.ipv6.iter().zip(interface.ipv6_scope_ids).map(|(ipv6, scope_id)| format!("{:?}%{}", ipv6, scope_id)).collect();
+        let ipv6_strs: Vec<String> = interface
+            .ipv6
+            .iter()
+            .zip(interface.ipv6_scope_ids)
+            .map(|(ipv6, scope_id)| format!("{:?}%{}", ipv6, scope_id))
+            .collect();
         println!("\tIPv6: [{}]", ipv6_strs.join(", "));
 
         println!("\tTransmit Speed: {:?}", interface.transmit_speed);

--- a/examples/list_interfaces.rs
+++ b/examples/list_interfaces.rs
@@ -24,7 +24,11 @@ fn main() {
             println!("\tMAC Address: (Failed to get mac address)");
         }
         println!("\tIPv4: {:?}", interface.ipv4);
-        println!("\tIPv6: {:?}", interface.ipv6);
+
+        // Print the IPv6 addresses with the scope ID after them as a suffix
+        let ipv6_strs: Vec<String> = interface.ipv6.iter().zip(interface.ipv6_scope_ids).map(|(ipv6, scope_id)| format!("{:?}%{}", ipv6, scope_id)).collect();
+        println!("\tIPv6: [{}]", ipv6_strs.join(", "));
+
         println!("\tTransmit Speed: {:?}", interface.transmit_speed);
         println!("\tReceive Speed: {:?}", interface.receive_speed);
         if let Some(gateway) = interface.gateway {

--- a/src/interface/android.rs
+++ b/src/interface/android.rs
@@ -101,6 +101,7 @@ pub mod netlink {
                 mac_addr: None,
                 ipv4: Vec::new(),
                 ipv6: Vec::new(),
+                ipv6_scope_ids: Vec::new(),
                 flags: link_msg.header.flags.bits(),
                 transmit_speed: None,
                 receive_speed: None,
@@ -152,7 +153,14 @@ pub mod netlink {
                                 Err(_) => {}
                             },
                             IpAddr::V6(ip) => match Ipv6Net::new(ip, addr_msg.header.prefix_len) {
-                                Ok(ipv6) => interface.ipv6.push(ipv6),
+                                Ok(ipv6) => {
+                                    interface.ipv6.push(ipv6);
+
+                                    // Note: On Unix platforms the scope ID is equal to the interface index, or at least
+                                    // that's what the glibc devs seemed to think when implementing getifaddrs!
+                                    // https://github.com/lattera/glibc/blob/895ef79e04a953cac1493863bcae29ad85657ee1/sysdeps/unix/sysv/linux/ifaddrs.c#L621
+                                    interface.ipv6_scope_ids.push(interface.index);
+                                }
                                 Err(_) => {}
                             },
                         }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -242,10 +242,7 @@ mod tests {
         // Try and find the loopback interface
         let loopback_interfaces: Vec<&Interface> = interfaces
             .iter()
-            .filter(|iface| match iface.mac_addr {
-                Some(mac) => crate::db::oui::is_known_loopback_mac(&mac),
-                None => false,
-            })
+            .filter(|iface| iface.if_type == InterfaceType::Loopback)
             .collect();
         assert_eq!(
             loopback_interfaces.len(),
@@ -282,9 +279,10 @@ mod tests {
         );
         println!("Found IP {:?} on the loopback interface", matching_ipv6s[0]);
 
-        // Make sure that the loopback has the same number of scope IDs as it does IPv6 addresses
+        // Make sure that the loopback interface has the same number of scope IDs as it does IPv6 addresses
         assert_eq!(loopback.ipv6.len(), loopback.ipv6_scope_ids.len());
 
+        // Check flags
         assert!(
             loopback.is_running(),
             "Loopback interface should be running!"
@@ -293,5 +291,11 @@ mod tests {
             !loopback.is_physical(),
             "Loopback interface should not be physical!"
         );
+
+        // Make sure that, if the loopback interface has a MAC, it has a known loopback MAC
+        match loopback.mac_addr {
+            Some(mac) => assert!(crate::db::oui::is_known_loopback_mac(&mac), "Loopback interface MAC not a known loopback MAC"),
+            None => {}
+        }
     }
 }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -294,7 +294,10 @@ mod tests {
 
         // Make sure that, if the loopback interface has a MAC, it has a known loopback MAC
         match loopback.mac_addr {
-            Some(mac) => assert!(crate::db::oui::is_known_loopback_mac(&mac), "Loopback interface MAC not a known loopback MAC"),
+            Some(mac) => assert!(
+                crate::db::oui::is_known_loopback_mac(&mac),
+                "Loopback interface MAC not a known loopback MAC"
+            ),
             None => {}
         }
     }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -74,10 +74,12 @@ pub struct Interface {
     pub ipv4: Vec<Ipv4Net>,
     /// List of Ipv6Nets (IPv6 address + netmask) for the network interface
     pub ipv6: Vec<Ipv6Net>,
-    /// List of Ipv6 Scope IDs for each of the corresponding elements in the ipv6 address vector.
+    /// List of IPv6 Scope IDs for each of the corresponding elements in the ipv6 address vector.
     /// The Scope ID is an integer which uniquely identifies this interface address on the system,
-    /// and generally has to be provided when opening a IPv6 socket on this interface for link-
-    /// local communications.
+    /// and must be provided when using link-local addressing to specify which interface
+    /// you wish to use. The scope ID can be the same as the interface index, but is not
+    /// required to be by the standard.
+    /// The scope ID can also be referred to as the zone index.
     pub ipv6_scope_ids: Vec<u32>,
     /// Flags for the network interface (OS Specific)
     pub flags: u32,

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -238,26 +238,58 @@ mod tests {
         assert!(interfaces.len() >= 2, "There should be at least 2 network interfaces on any machine, the loopback and one other one");
 
         // Try and find the loopback interface
-        let loopback_interfaces: Vec<&Interface> = interfaces.iter().filter(|iface| match iface.mac_addr { Some(mac) => crate::db::oui::is_known_loopback_mac(&mac), None => false}).collect();
-        assert_eq!(loopback_interfaces.len(), 1, "There should be exactly one loopback interface on the machine");
+        let loopback_interfaces: Vec<&Interface> = interfaces
+            .iter()
+            .filter(|iface| match iface.mac_addr {
+                Some(mac) => crate::db::oui::is_known_loopback_mac(&mac),
+                None => false,
+            })
+            .collect();
+        assert_eq!(
+            loopback_interfaces.len(),
+            1,
+            "There should be exactly one loopback interface on the machine"
+        );
         let loopback = loopback_interfaces[0];
 
         // Make sure that 127.0.0.1 is one of loopback's IPv4 addresses
         let loopback_expected_ipv4: std::net::Ipv4Addr = "127.0.0.1".parse().unwrap();
-        let matching_ipv4s: Vec<&Ipv4Net> = loopback.ipv4.iter().filter(|&ipv4_net| ipv4_net.addr() == loopback_expected_ipv4).collect();
-        assert_eq!(matching_ipv4s.len(), 1, "The loopback interface should have IP 127.0.0.1");
+        let matching_ipv4s: Vec<&Ipv4Net> = loopback
+            .ipv4
+            .iter()
+            .filter(|&ipv4_net| ipv4_net.addr() == loopback_expected_ipv4)
+            .collect();
+        assert_eq!(
+            matching_ipv4s.len(),
+            1,
+            "The loopback interface should have IP 127.0.0.1"
+        );
         println!("Found IP {:?} on the loopback interface", matching_ipv4s[0]);
 
         // Make sure that ::1 is one of loopback's IPv6 addresses
         let loopback_expected_ipv6: std::net::Ipv6Addr = "::1".parse().unwrap();
-        let matching_ipv6s: Vec<&Ipv6Net> = loopback.ipv6.iter().filter(|&ipv6_net| ipv6_net.addr() == loopback_expected_ipv6).collect();
-        assert_eq!(matching_ipv6s.len(), 1, "The loopback interface should have IP ::1");
+        let matching_ipv6s: Vec<&Ipv6Net> = loopback
+            .ipv6
+            .iter()
+            .filter(|&ipv6_net| ipv6_net.addr() == loopback_expected_ipv6)
+            .collect();
+        assert_eq!(
+            matching_ipv6s.len(),
+            1,
+            "The loopback interface should have IP ::1"
+        );
         println!("Found IP {:?} on the loopback interface", matching_ipv6s[0]);
 
         // Make sure that the loopback has the same number of scope IDs as it does IPv6 addresses
         assert_eq!(loopback.ipv6.len(), loopback.ipv6_scope_ids.len());
 
-        assert!(loopback.is_running(), "Loopback interface should be running!");
-        assert!(!loopback.is_physical(), "Loopback interface should not be physical!");
+        assert!(
+            loopback.is_running(),
+            "Loopback interface should be running!"
+        );
+        assert!(
+            !loopback.is_physical(),
+            "Loopback interface should not be physical!"
+        );
     }
 }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -52,21 +52,27 @@ use std::net::IpAddr;
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Interface {
-    /// Index of network interface
+    /// Index of network interface. This is an integer which uniquely identifies the interface
+    /// on this machine.
     pub index: u32,
-    /// Name of network interface
+    /// Machine-readable name of the network interface. On unix-like OSs, this is the interface
+    /// name, like 'eth0' or 'eno1'. On Windows, this is the interface's GUID as a string.
     pub name: String,
-    /// Friendly Name of network interface
+    /// Friendly name of network interface. On Windows, this is the network adapter configured
+    /// name, e.g. "Ethernet 5" or "Wi-Fi". On Mac, this is the interface display name,
+    /// such as "Ethernet" or "FireWire". If no friendly name is available, this is left as None.
     pub friendly_name: Option<String>,
-    /// Description of the network interface
+    /// Description of the network interface. On Windows, this is the network adapter model, such
+    /// as "Realtek USB GbE Family Controller #4" or "Software Loopback Interface 1". Currently
+    /// this is not available on platforms other than Windows.
     pub description: Option<String>,
     /// Interface Type
     pub if_type: InterfaceType,
     /// MAC address of network interface
     pub mac_addr: Option<MacAddr>,
-    /// List of Ipv4Net for the network interface
+    /// List of Ipv4Nets (IPv4 address + netmask) for the network interface
     pub ipv4: Vec<Ipv4Net>,
-    /// List of Ipv6Net for the network interface
+    /// List of Ipv6Nets (IPv6 address + netmask) for the network interface
     pub ipv6: Vec<Ipv6Net>,
     /// List of Ipv6 Scope IDs for each of the corresponding elements in the ipv6 address vector.
     /// The Scope ID is an integer which uniquely identifies this interface address on the system,
@@ -75,15 +81,19 @@ pub struct Interface {
     pub ipv6_scope_ids: Vec<u32>,
     /// Flags for the network interface (OS Specific)
     pub flags: u32,
-    /// Speed in bits per second of the transmit for the network interface
+    /// Speed in bits per second of the transmit for the network interface, if known.
+    /// Currently only supported on Linux, Android, and Windows.
     pub transmit_speed: Option<u64>,
-    /// Speed in bits per second of the receive for the network interface
+    /// Speed in bits per second of the receive for the network interface.
+    /// Currently only supported on Linux, Android, and Windows.
     pub receive_speed: Option<u64>,
-    /// Default gateway for the network interface
+    /// Default gateway for the network interface. This is the address of the router to which
+    /// IP packets are forwarded when they need to be sent to a device outside
+    /// of the local network.
     pub gateway: Option<NetworkDevice>,
-    /// DNS servers for the network interface
+    /// DNS server addresses for the network interface
     pub dns_servers: Vec<IpAddr>,
-    /// is default interface
+    /// Whether this is the default interface for accessing the Internet.
     pub default: bool,
 }
 

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -256,5 +256,8 @@ mod tests {
 
         // Make sure that the loopback has the same number of scope IDs as it does IPv6 addresses
         assert_eq!(loopback.ipv6.len(), loopback.ipv6_scope_ids.len());
+
+        assert!(loopback.is_running(), "Loopback interface should be running!");
+        assert!(!loopback.is_physical(), "Loopback interface should not be physical!");
     }
 }

--- a/src/interface/unix.rs
+++ b/src/interface/unix.rs
@@ -184,7 +184,9 @@ pub(super) fn sockaddr_to_network_addr(
     target_os = "macos",
     target_os = "ios"
 ))]
-fn sockaddr_to_network_addr(sa: *mut libc::sockaddr) -> (Option<MacAddr>, Option<IpAddr>, Option<u32>) {
+fn sockaddr_to_network_addr(
+    sa: *mut libc::sockaddr,
+) -> (Option<MacAddr>, Option<IpAddr>, Option<u32>) {
     use std::net::SocketAddr;
 
     unsafe {

--- a/src/interface/unix.rs
+++ b/src/interface/unix.rs
@@ -141,15 +141,17 @@ pub fn interfaces() -> Vec<Interface> {
     interfaces
 }
 
+// Convert a socket address struct into a Rust IP address or MAC address struct.
+// If the socket address is an IPv6 address, also returns the scope ID.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub(super) fn sockaddr_to_network_addr(
     sa: *mut libc::sockaddr,
-) -> (Option<MacAddr>, Option<IpAddr>) {
+) -> (Option<MacAddr>, Option<IpAddr>, Option<u32>) {
     use std::net::SocketAddr;
 
     unsafe {
         if sa.is_null() {
-            (None, None)
+            (None, None, None)
         } else if (*sa).sa_family as libc::c_int == libc::AF_PACKET {
             let sll: *const libc::sockaddr_ll = mem::transmute(sa);
             let mac = MacAddr(
@@ -161,15 +163,15 @@ pub(super) fn sockaddr_to_network_addr(
                 (*sll).sll_addr[5],
             );
 
-            (Some(mac), None)
+            (Some(mac), None, None)
         } else {
             let addr =
                 sys::sockaddr_to_addr(mem::transmute(sa), mem::size_of::<libc::sockaddr_storage>());
 
             match addr {
-                Ok(SocketAddr::V4(sa)) => (None, Some(IpAddr::V4(*sa.ip()))),
-                Ok(SocketAddr::V6(sa)) => (None, Some(IpAddr::V6(*sa.ip()))),
-                Err(_) => (None, None),
+                Ok(SocketAddr::V4(sa)) => (None, Some(IpAddr::V4(*sa.ip())), None),
+                Ok(SocketAddr::V6(sa)) => (None, Some(IpAddr::V6(*sa.ip())), Some(sa.scope_id())),
+                Err(_) => (None, None, None),
             }
         }
     }
@@ -296,10 +298,10 @@ fn unix_interfaces_inner(
         let c_str = addr_ref.ifa_name as *const c_char;
         let bytes = unsafe { CStr::from_ptr(c_str).to_bytes() };
         let name = unsafe { from_utf8_unchecked(bytes).to_owned() };
-        let (mac, ip) = sockaddr_to_network_addr(addr_ref.ifa_addr as *mut libc::sockaddr);
-        let (_, netmask) = sockaddr_to_network_addr(addr_ref.ifa_netmask as *mut libc::sockaddr);
-        let mut ini_ipv4: Vec<Ipv4Net> = vec![];
-        let mut ini_ipv6: Vec<Ipv6Net> = vec![];
+        let (mac, ip, ipv6_scope_id) = sockaddr_to_network_addr(addr_ref.ifa_addr as *mut libc::sockaddr);
+        let (_, netmask, _) = sockaddr_to_network_addr(addr_ref.ifa_netmask as *mut libc::sockaddr);
+        let mut ini_ipv4: Option<Ipv4Net> = None;
+        let mut ini_ipv6: Option<Ipv6Net> = None;
         if let Some(ip) = ip {
             match ip {
                 IpAddr::V4(ipv4) => {
@@ -311,7 +313,9 @@ fn unix_interfaces_inner(
                         None => Ipv4Addr::UNSPECIFIED,
                     };
                     match Ipv4Net::with_netmask(ipv4, netmask) {
-                        Ok(ipv4_net) => ini_ipv4.push(ipv4_net),
+                        Ok(ipv4_net) => {
+                            ini_ipv4 = Some(ipv4_net)
+                        },
                         Err(_) => {}
                     }
                 }
@@ -324,68 +328,57 @@ fn unix_interfaces_inner(
                         None => Ipv6Addr::UNSPECIFIED,
                     };
                     match Ipv6Net::with_netmask(ipv6, netmask) {
-                        Ok(ipv6_net) => ini_ipv6.push(ipv6_net),
+                        Ok(ipv6_net) => {
+                            ini_ipv6 = Some(ipv6_net);
+                            if ipv6_scope_id.is_none() {
+                                panic!("IPv6 address without scope ID!")
+                            }
+                        },
                         Err(_) => {}
-                    }
+                    };
                 }
             }
         }
-        let interface: Interface = Interface {
-            index: 0,
-            name: name.clone(),
-            friendly_name: None,
-            description: None,
-            if_type: if_type,
-            mac_addr: mac.clone(),
-            ipv4: ini_ipv4,
-            ipv6: ini_ipv6,
-            flags: addr_ref.ifa_flags,
-            transmit_speed: None,
-            receive_speed: None,
-            gateway: None,
-            dns_servers: Vec::new(),
-            default: false,
-        };
+
+        // Check if there is already an interface with this name (since getifaddrs returns one
+        // entry per address, so if the interface has multiple addresses, it returns multiple entries).
+        // If so, add the IP addresses from the current entry into the existing interface. Otherwise, add a new interface.
         let mut found: bool = false;
         for iface in &mut ifaces {
             if name == iface.name {
                 if let Some(mac) = mac.clone() {
                     iface.mac_addr = Some(mac);
                 }
-                if let Some(ip) = ip {
-                    match ip {
-                        IpAddr::V4(ipv4) => {
-                            let netmask: Ipv4Addr = match netmask {
-                                Some(netmask) => match netmask {
-                                    IpAddr::V4(netmask) => netmask,
-                                    IpAddr::V6(_) => Ipv4Addr::UNSPECIFIED,
-                                },
-                                None => Ipv4Addr::UNSPECIFIED,
-                            };
-                            match Ipv4Net::with_netmask(ipv4, netmask) {
-                                Ok(ipv4_net) => iface.ipv4.push(ipv4_net),
-                                Err(_) => {}
-                            }
-                        }
-                        IpAddr::V6(ipv6) => {
-                            let netmask: Ipv6Addr = match netmask {
-                                Some(netmask) => match netmask {
-                                    IpAddr::V4(_) => Ipv6Addr::UNSPECIFIED,
-                                    IpAddr::V6(netmask) => netmask,
-                                },
-                                None => Ipv6Addr::UNSPECIFIED,
-                            };
-                            match Ipv6Net::with_netmask(ipv6, netmask) {
-                                Ok(ipv6_net) => iface.ipv6.push(ipv6_net),
-                                Err(_) => {}
-                            }
-                        }
-                    }
+
+                if ini_ipv4.is_some() {
+                    iface.ipv4.push(ini_ipv4.unwrap());
+                }
+
+                if ini_ipv6.is_some() {
+                    iface.ipv6.push(ini_ipv6.unwrap());
+                    iface.ipv6_scope_ids.push(ipv6_scope_id.unwrap());
                 }
                 found = true;
             }
         }
         if !found {
+            let interface: Interface = Interface {
+                index: 0, // We will set these below
+                name: name.clone(),
+                friendly_name: None,
+                description: None,
+                if_type: if_type,
+                mac_addr: mac.clone(),
+                ipv4: match ini_ipv4 { Some(ipv4_addr) => vec![ipv4_addr], None => vec![]},
+                ipv6: match ini_ipv6 { Some(ipv6_addr) => vec![ipv6_addr], None => vec![]},
+                ipv6_scope_ids: match ini_ipv6 { Some(_) => vec![ipv6_scope_id.unwrap()], None => vec![]},
+                flags: addr_ref.ifa_flags,
+                transmit_speed: None,
+                receive_speed: None,
+                gateway: None,
+                dns_servers: Vec::new(),
+                default: false,
+            };
             ifaces.push(interface);
         }
         addr = addr_ref.ifa_next;
@@ -400,16 +393,4 @@ fn unix_interfaces_inner(
         }
     }
     ifaces
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn test_unix_interfaces() {
-        let interfaces = interfaces();
-        for interface in interfaces {
-            println!("{:#?}", interface);
-        }
-    }
 }

--- a/src/interface/unix.rs
+++ b/src/interface/unix.rs
@@ -298,7 +298,8 @@ fn unix_interfaces_inner(
         let c_str = addr_ref.ifa_name as *const c_char;
         let bytes = unsafe { CStr::from_ptr(c_str).to_bytes() };
         let name = unsafe { from_utf8_unchecked(bytes).to_owned() };
-        let (mac, ip, ipv6_scope_id) = sockaddr_to_network_addr(addr_ref.ifa_addr as *mut libc::sockaddr);
+        let (mac, ip, ipv6_scope_id) =
+            sockaddr_to_network_addr(addr_ref.ifa_addr as *mut libc::sockaddr);
         let (_, netmask, _) = sockaddr_to_network_addr(addr_ref.ifa_netmask as *mut libc::sockaddr);
         let mut ini_ipv4: Option<Ipv4Net> = None;
         let mut ini_ipv6: Option<Ipv6Net> = None;
@@ -313,9 +314,7 @@ fn unix_interfaces_inner(
                         None => Ipv4Addr::UNSPECIFIED,
                     };
                     match Ipv4Net::with_netmask(ipv4, netmask) {
-                        Ok(ipv4_net) => {
-                            ini_ipv4 = Some(ipv4_net)
-                        },
+                        Ok(ipv4_net) => ini_ipv4 = Some(ipv4_net),
                         Err(_) => {}
                     }
                 }
@@ -333,7 +332,7 @@ fn unix_interfaces_inner(
                             if ipv6_scope_id.is_none() {
                                 panic!("IPv6 address without scope ID!")
                             }
-                        },
+                        }
                         Err(_) => {}
                     };
                 }
@@ -369,9 +368,18 @@ fn unix_interfaces_inner(
                 description: None,
                 if_type: if_type,
                 mac_addr: mac.clone(),
-                ipv4: match ini_ipv4 { Some(ipv4_addr) => vec![ipv4_addr], None => vec![]},
-                ipv6: match ini_ipv6 { Some(ipv6_addr) => vec![ipv6_addr], None => vec![]},
-                ipv6_scope_ids: match ini_ipv6 { Some(_) => vec![ipv6_scope_id.unwrap()], None => vec![]},
+                ipv4: match ini_ipv4 {
+                    Some(ipv4_addr) => vec![ipv4_addr],
+                    None => vec![],
+                },
+                ipv6: match ini_ipv6 {
+                    Some(ipv6_addr) => vec![ipv6_addr],
+                    None => vec![],
+                },
+                ipv6_scope_ids: match ini_ipv6 {
+                    Some(_) => vec![ipv6_scope_id.unwrap()],
+                    None => vec![],
+                },
                 flags: addr_ref.ifa_flags,
                 transmit_speed: None,
                 receive_speed: None,

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -16,6 +16,7 @@ fn ntohs(u: u16) -> u16 {
     u16::from_be(u)
 }
 
+// Converts libc socket address type to Rust SocketAddr struct
 pub fn sockaddr_to_addr(storage: &SockAddrStorage, len: usize) -> io::Result<SocketAddr> {
     match storage.ss_family as libc::c_int {
         AF_INET => {


### PR DESCRIPTION
Hello! I'm Jamie, I'm starting to work on a set of Python bindings for this library to replace the long-deprecated `netifaces` library (that lots of people are still stuck using, including me for my multicast_expert library). I've really liked what I've seen of this library so far, and it seems like a great tool to adapt for the Python world.

There is, however, one missing feature that I need to add for my use case. In order to open an IPv6 multicast socket (on Linux at least), I need to know the scope ID of the interface. Scope IDs are a somewhat rarely used feature of IPv6, and honestly I haven't found much info about them other than the [actual RFC that defined them](https://datatracker.ietf.org/doc/html/rfc4007#section-6). Basically, they are used to uniquely identify a link-local destination address so that the OS knows what interface it's supposed to be sent to.

For instance, suppose an application wants to send a packet to the address `fe80::1`. This is a link local address, so it's actually valid on any of the network links the machine has. To resolve that ambiguity, the network address has to be suffixed with a scope ID (also called a zone index), like `fe80::1%5`. This tells the OS to send the packet out the interface associated with zone index 5. OSs may also support string scope IDs in addresses, like `fe80::1%eth0`, but this is just syntactic sugar for the same thing.

So that applications can make use of scope IDs, this PR adds support for reporting the scope ID for each of the IPv6 addresses that an interface has. Thankfully the scope ID is already reported by getifaddrs and GetAdaptersAddresses, so all I had to do was pass it up the chain to the API. Unfortunately, unlike the corresponding Python class, the Rust Ipv6Addr class does not support storing the scope ID, so I have to make a separate vector for them.

I also took the chance to make some minor cleanups that seemed like they would be helpful, including:
- Better documenting some of the members of the Interface struct
- Removing some duplicate code in unix_interfaces_inner()
- Adding a new test case that verifies attributes of the loopback interface

*Note:* I still have some open questions about scope IDs, including:
- Are they always the same as the interface index? In practice they seem to be, but the RFC says this is not necessarily true.
  - Update: Linux C libraries (glibc and musl-libc) do indeed seem to [make this assumption](https://git.musl-libc.org/cgit/musl/tree/src/network/getifaddrs.c#n70), but only for link local addresses? Unclear what happens for non link local addresses -- does it leave the interface index as 0?
- Does every IPv6 address of an interface have the same scope ID? OSs generally return a different scope ID for each address, so I figured it was better to hedge our bets and maintain this association in the rust API, even though we could _probably_ just have one scope ID for the interface.

*Note 2:* I'm still new to Rust so hopefully I didn't make a complete hash of this. Please let me know how this code could be improved!