### PR TITLE
chore: bump rtnetlink

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ dlopen2 = { version = "0.5", default-features = false }
 once_cell = "1"
 # netlink
 netlink-packet-core = "0.7"
-netlink-packet-route = "0.21"
+netlink-packet-route = "0.22.0"
 netlink-sys = "0.8"
 
 [target.'cfg(windows)'.dependencies.windows-sys]


### PR DESCRIPTION
The old version is causing or CI to reject our build (cargo-deny) based on duplicate dependencies.
