### PR TITLE
fix parsing IPv6 gateway

### DIFF
--- a/src/gateway/linux.rs
+++ b/src/gateway/linux.rs
@@ -91,7 +91,7 @@ fn get_ipv6_gateway_map() -> HashMap<String, Ipv6Addr> {
     };
     let route_table: Vec<&str> = route_text.trim().split("\n").collect();
     for row in route_table {
-        let fields: Vec<&str> = row.split("\t").collect();
+        let fields: Vec<&str> = row.split_whitespace().collect();
         if fields.len() >= 10 {
             // fields[4]: IPv6 Address 32 hex chars without colons
             // fields[9]: Interface Name


### PR DESCRIPTION
"/proc/net/ipv6_route" doesn't contain tabs like "/proc/net/route" does, but spaces instead. 
So https://github.com/shellrow/netdev/blob/dcf4eb745204c14b3afb4b1df7b8fdabfc5a7ce2/src/gateway/linux.rs#L94 is broken and doesn't parse any IPv6 addresses

current: 
`fields (1): [
    "fe800000000000000000000000000000 40 00000000000000000000000000000000 00 00000000000000000000000000000000 00000100 00000001 00000000 00000001     eth0",
]`

with fix:
`fields (10): [
    "fe800000000000000000000000000000",
    "40",
    "00000000000000000000000000000000",
    "00",
    "00000000000000000000000000000000",
    "00000100",
    "00000001",
    "00000000",
    "00000001",
    "eth0",
]`