### PR TITLE
Fix parsing correct IPv6 gateway on linux

### DIFF
--- a/src/gateway/linux.rs
+++ b/src/gateway/linux.rs
@@ -93,9 +93,16 @@ fn get_ipv6_gateway_map() -> HashMap<String, Ipv6Addr> {
     for row in route_table {
         let fields: Vec<&str> = row.split_whitespace().collect();
         if fields.len() >= 10 {
+            // fields[0]: destination
+            // fields[1]: destination prefix length
             // fields[4]: IPv6 Address 32 hex chars without colons
             // fields[9]: Interface Name
-            if fields[4] != "00000000000000000000000000000000" {
+
+            // default route has zero destination and zero prefix length
+            if fields[0] == "00000000000000000000000000000000" &&
+               fields[1] == "00" &&
+               fields[4] != "00000000000000000000000000000000"
+            {
                 ipv6_gateway_map.insert(fields[9].to_string(), convert_hex_ipv6(fields[4]));
             }
         }

--- a/src/gateway/linux.rs
+++ b/src/gateway/linux.rs
@@ -99,9 +99,9 @@ fn get_ipv6_gateway_map() -> HashMap<String, Ipv6Addr> {
             // fields[9]: Interface Name
 
             // default route has zero destination and zero prefix length
-            if fields[0] == "00000000000000000000000000000000" &&
-               fields[1] == "00" &&
-               fields[4] != "00000000000000000000000000000000"
+            if fields[0] == "00000000000000000000000000000000"
+                && fields[1] == "00"
+                && fields[4] != "00000000000000000000000000000000"
             {
                 ipv6_gateway_map.insert(fields[9].to_string(), convert_hex_ipv6(fields[4]));
             }


### PR DESCRIPTION
Currently all IPs from routes /proc/net/ipv6_route are selected instead of just the gateway.

Added filter for selecting default route.