### PR TITLE
Fix linux interfaces

### DIFF
--- a/src/interface/linux.rs
+++ b/src/interface/linux.rs
@@ -19,7 +19,7 @@ pub fn is_virtual_interface(interface_name: &str) -> bool {
     }
 }
 
-pub fn get_interface_type(if_name: String) -> InterfaceType {
+pub fn get_interface_type(if_name: &str) -> InterfaceType {
     let if_type_path: String = format!("/sys/class/net/{}/type", if_name);
     let r = read_to_string(if_type_path);
     match r {
@@ -50,7 +50,7 @@ pub fn get_interface_type(if_name: String) -> InterfaceType {
     };
 }
 
-pub fn get_interface_speed(if_name: String) -> Option<u64> {
+pub fn get_interface_speed(if_name: &str) -> Option<u64> {
     let if_speed_path: String = format!("/sys/class/net/{}/speed", if_name);
     let r = read_to_string(if_speed_path);
     match r {

--- a/src/interface/unix.rs
+++ b/src/interface/unix.rs
@@ -89,9 +89,9 @@ pub fn interfaces() -> Vec<Interface> {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn interfaces() -> Vec<Interface> {
     #[cfg(feature = "gateway")]
-    use std::collections::HashMap;
-    #[cfg(feature = "gateway")]
     use crate::NetworkDevice;
+    #[cfg(feature = "gateway")]
+    use std::collections::HashMap;
 
     use super::linux;
 

--- a/src/interface/unix.rs
+++ b/src/interface/unix.rs
@@ -104,8 +104,8 @@ pub fn interfaces() -> Vec<Interface> {
     let gateway_map: HashMap<String, NetworkDevice> = gateway::linux::get_gateway_map();
 
     for iface in &mut interfaces {
-        iface.if_type = linux::get_interface_type(iface.name.clone());
-        let if_speed: Option<u64> = linux::get_interface_speed(iface.name.clone());
+        iface.if_type = linux::get_interface_type(&iface.name);
+        let if_speed: Option<u64> = linux::get_interface_speed(&iface.name);
         iface.transmit_speed = if_speed;
         iface.receive_speed = if_speed;
 

--- a/src/interface/unix.rs
+++ b/src/interface/unix.rs
@@ -88,42 +88,51 @@ pub fn interfaces() -> Vec<Interface> {
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn interfaces() -> Vec<Interface> {
+    #[cfg(feature = "gateway")]
+    use std::collections::HashMap;
+    #[cfg(feature = "gateway")]
+    use crate::NetworkDevice;
+
     use super::linux;
 
     let mut interfaces: Vec<Interface> = unix_interfaces();
 
     #[cfg(feature = "gateway")]
-    let local_ip: IpAddr = match super::get_local_ipaddr() {
-        Some(local_ip) => local_ip,
-        None => return interfaces,
-    };
+    let local_ip_opt: Option<IpAddr> = super::get_local_ipaddr();
+
     #[cfg(feature = "gateway")]
-    let gateway_map = gateway::linux::get_gateway_map();
+    let gateway_map: HashMap<String, NetworkDevice> = gateway::linux::get_gateway_map();
+
     for iface in &mut interfaces {
         iface.if_type = linux::get_interface_type(iface.name.clone());
         let if_speed: Option<u64> = linux::get_interface_speed(iface.name.clone());
         iface.transmit_speed = if_speed;
         iface.receive_speed = if_speed;
+
         #[cfg(feature = "gateway")]
         if let Some(gateway) = gateway_map.get(&iface.name) {
             iface.gateway = Some(gateway.clone());
         }
+
         #[cfg(feature = "gateway")]
-        match local_ip {
-            IpAddr::V4(local_ipv4) => {
-                if iface.ipv4.iter().any(|x| x.addr() == local_ipv4) {
-                    iface.default = true;
-                    iface.dns_servers = get_system_dns_conf();
+        if let Some(local_ip) = local_ip_opt {
+            match local_ip {
+                IpAddr::V4(local_ipv4) => {
+                    if iface.ipv4.iter().any(|x| x.addr() == local_ipv4) {
+                        iface.default = true;
+                        iface.dns_servers = get_system_dns_conf();
+                    }
                 }
-            }
-            IpAddr::V6(local_ipv6) => {
-                if iface.ipv6.iter().any(|x| x.addr() == local_ipv6) {
-                    iface.default = true;
-                    iface.dns_servers = get_system_dns_conf();
+                IpAddr::V6(local_ipv6) => {
+                    if iface.ipv6.iter().any(|x| x.addr() == local_ipv6) {
+                        iface.default = true;
+                        iface.dns_servers = get_system_dns_conf();
+                    }
                 }
             }
         }
     }
+
     interfaces
 }
 


### PR DESCRIPTION
- fix: always populate interface fields even if local_ip is None (linux & android)
- refactor: accept `&str` in `get_interface_type` and `get_interface_speed`