### PR TITLE
Support all Apple-vended OSes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,14 @@ netlink-sys = "0.8"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.59"
-features = ["Win32_Foundation", "Win32_NetworkManagement_IpHelper", "Win32_Networking_WinSock", "Win32_NetworkManagement_Ndis"]
+features = [
+    "Win32_Foundation",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_Networking_WinSock",
+    "Win32_NetworkManagement_Ndis",
+]
 
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+[target.'cfg(target_vendor = "apple")'.dependencies]
 system-configuration = "0.6"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project was rebranded from [default-net][default-net-crates-io-url] by the 
 
 ## Supported platform
 - Linux
-- macOS
+- macOS and other Apple targets (iOS, watchOS, tvOS, etc.)
 - Windows
 
 ## Usage

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(any(target_os = "openbsd", target_os = "freebsd", target_os = "netbsd"))]
 pub(crate) mod bsd;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_vendor = "apple")]
 pub(crate) mod macos;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -8,21 +8,19 @@ pub use self::types::*;
 
 #[cfg(any(
     target_os = "linux",
-    target_os = "macos",
+    target_vendor = "apple",
     target_os = "openbsd",
     target_os = "freebsd",
     target_os = "netbsd",
-    target_os = "ios",
     target_os = "android"
 ))]
 mod unix;
 #[cfg(any(
     target_os = "linux",
-    target_os = "macos",
+    target_vendor = "apple",
     target_os = "openbsd",
     target_os = "freebsd",
     target_os = "netbsd",
-    target_os = "ios",
     target_os = "android"
 ))]
 use self::unix::*;
@@ -41,7 +39,7 @@ mod linux;
 #[cfg(target_os = "android")]
 mod android;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_vendor = "apple")]
 mod macos;
 #[cfg(feature = "gateway")]
 use crate::device::NetworkDevice;

--- a/src/interface/types.rs
+++ b/src/interface/types.rs
@@ -135,11 +135,10 @@ impl InterfaceType {
     }
     /// Returns OS-specific value of InterfaceType
     #[cfg(any(
-        target_os = "macos",
+        target_vendor = "apple",
         target_os = "openbsd",
         target_os = "freebsd",
-        target_os = "netbsd",
-        target_os = "ios"
+        target_os = "netbsd"
     ))]
     pub fn value(&self) -> u32 {
         match *self {

--- a/src/interface/unix.rs
+++ b/src/interface/unix.rs
@@ -46,7 +46,7 @@ pub fn get_system_dns_conf() -> Vec<IpAddr> {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_vendor = "apple")]
 pub fn interfaces() -> Vec<Interface> {
     use super::macos;
 
@@ -214,11 +214,10 @@ pub(super) fn sockaddr_to_network_addr(
 }
 
 #[cfg(any(
+    target_vendor = "apple",
     target_os = "openbsd",
     target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "macos",
-    target_os = "ios"
+    target_os = "netbsd"
 ))]
 fn sockaddr_to_network_addr(
     sa: *mut libc::sockaddr,
@@ -261,8 +260,7 @@ fn sockaddr_to_network_addr(
 }
 
 #[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
+    target_vendor = "apple",
     target_os = "openbsd",
     target_os = "freebsd",
     target_os = "netbsd"
@@ -286,8 +284,7 @@ pub fn is_running(interface: &Interface) -> bool {
 }
 
 #[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
+    target_vendor = "apple",
     target_os = "openbsd",
     target_os = "freebsd",
     target_os = "netbsd"
@@ -304,8 +301,7 @@ pub fn is_physical_interface(interface: &Interface) -> bool {
 }
 
 #[cfg(any(
-    target_os = "macos",
-    target_os = "ios",
+    target_vendor = "apple",
     target_os = "openbsd",
     target_os = "freebsd",
     target_os = "netbsd"


### PR DESCRIPTION
This PR changes the cfg-gating of macOS + iOS to all Apple platforms (via target_vendor). This ensures netdev also compiles on watchOS, tvOS, and visionOS.

These are all _roughly the same to netdev_ but are treated by Rust as separate targets.