### PR TITLE
Add interface traffic stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+scripts/* linguist-vendored

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,7 @@ required-features = ["serde", "gateway"]
 name = "global_ips"
 path = "examples/global_ips.rs"
 required-features = ["gateway"]
+
+[[example]]
+name = "stats"
+path = "examples/stats.rs"

--- a/examples/default_interface.rs
+++ b/examples/default_interface.rs
@@ -27,6 +27,7 @@ fn main() {
             println!("\tIPv6: {:?}", interface.ipv6);
             println!("\tTransmit Speed: {:?}", interface.transmit_speed);
             println!("\tReceive Speed: {:?}", interface.receive_speed);
+            println!("\tStats: {:?}", interface.stats);
             if let Some(gateway) = interface.gateway {
                 println!("Default Gateway");
                 println!("\tMAC Address: {}", gateway.mac_addr);

--- a/examples/list_interfaces.rs
+++ b/examples/list_interfaces.rs
@@ -36,6 +36,7 @@ fn main() {
 
         println!("\tTransmit Speed: {:?}", interface.transmit_speed);
         println!("\tReceive Speed: {:?}", interface.receive_speed);
+        println!("\tStats: {:?}", interface.stats);
         #[cfg(feature = "gateway")]
         if let Some(gateway) = interface.gateway {
             println!("Gateway");

--- a/examples/stats.rs
+++ b/examples/stats.rs
@@ -5,7 +5,10 @@ use netdev::{self, Interface};
 
 fn main() -> std::io::Result<()> {
     let mut iface = netdev::get_default_interface().expect("No default interface found");
-    println!("Monitoring default interface: [{}]{}\n", iface.index, iface.name);
+    println!(
+        "Monitoring default interface: [{}]{}\n",
+        iface.index, iface.name
+    );
 
     // Initial stats
     println!("[Initial stats]");
@@ -27,7 +30,9 @@ fn print_stats(iface: &Interface) {
         Some(stats) => {
             println!(
                 "RX: {:>12} bytes, TX: {:>12} bytes at {:?}",
-                stats.rx_bytes, stats.tx_bytes, stats.timestamp.unwrap_or(SystemTime::UNIX_EPOCH)
+                stats.rx_bytes,
+                stats.tx_bytes,
+                stats.timestamp.unwrap_or(SystemTime::UNIX_EPOCH)
             );
         }
         None => {

--- a/examples/stats.rs
+++ b/examples/stats.rs
@@ -1,0 +1,37 @@
+use std::thread::sleep;
+use std::time::{Duration, SystemTime};
+
+use netdev::{self, Interface};
+
+fn main() -> std::io::Result<()> {
+    let mut iface = netdev::get_default_interface().expect("No default interface found");
+    println!("Monitoring default interface: [{}]{}\n", iface.index, iface.name);
+
+    // Initial stats
+    println!("[Initial stats]");
+    print_stats(&iface);
+
+    // Update stats every second for 3 seconds
+    for i in 1..=3 {
+        sleep(Duration::from_secs(1));
+        iface.update_stats()?;
+        println!("\n[Update {}]", i);
+        print_stats(&iface);
+    }
+
+    Ok(())
+}
+
+fn print_stats(iface: &Interface) {
+    match &iface.stats {
+        Some(stats) => {
+            println!(
+                "RX: {:>12} bytes, TX: {:>12} bytes at {:?}",
+                stats.rx_bytes, stats.tx_bytes, stats.timestamp.unwrap_or(SystemTime::UNIX_EPOCH)
+            );
+        }
+        None => {
+            println!("No statistics available for interface: {}", iface.name);
+        }
+    }
+}

--- a/scripts/build-all.ps1
+++ b/scripts/build-all.ps1
@@ -1,0 +1,20 @@
+# build-all.ps1
+
+$targets = @(
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-unknown-freebsd",
+    "aarch64-linux-android",
+    "x86_64-linux-android"
+)
+
+foreach ($target in $targets) {
+    Write-Host "==> Building for $target..."
+    $result = & cross build --target $target
+    Write-Host "✅ Success: $target"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "❌ Build failed for $target"
+        exit 1
+    }
+}
+Write-Host "✅ All builds succeeded."

--- a/scripts/build-all.ps1
+++ b/scripts/build-all.ps1
@@ -1,5 +1,4 @@
-# build-all.ps1
-
+# target platforms
 $targets = @(
     "x86_64-unknown-linux-gnu",
     "aarch64-unknown-linux-gnu",
@@ -8,6 +7,7 @@ $targets = @(
     "x86_64-linux-android"
 )
 
+# cross build
 foreach ($target in $targets) {
     Write-Host "==> Building for $target..."
     $result = & cross build --target $target

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -e
+
+# target platforms
+TARGETS=(
+    x86_64-unknown-linux-gnu
+    aarch64-unknown-linux-gnu
+    x86_64-unknown-freebsd
+    aarch64-linux-android
+    x86_64-linux-android
+)
+
+# cross build
+for target in "${TARGETS[@]}"; do
+    echo "==> Building for $target..."
+    if cross build --target "$target"; then
+        echo "✅ Success: $target"
+    else
+        echo "❌ Failed: $target"
+        exit 1
+    fi
+done
+
+echo ""
+echo "✅ All builds succeeded!"

--- a/src/interface/android.rs
+++ b/src/interface/android.rs
@@ -66,6 +66,8 @@ pub mod netlink {
         mac::MacAddr,
     };
 
+    use crate::stats::{InterfaceStats, get_stats};
+
     pub fn unix_interfaces() -> Vec<Interface> {
         let mut ifaces = Vec::new();
         if let Ok(socket) = Socket::new(NETLINK_ROUTE) {
@@ -86,6 +88,10 @@ pub mod netlink {
                 eprintln!("unable to list addresses: {:?}", err);
             }
         }
+        for iface in &mut ifaces {
+            let stats: Option<InterfaceStats> = get_stats(None, &iface.name);
+            iface.stats = stats;
+        }
         ifaces
     }
 
@@ -105,6 +111,7 @@ pub mod netlink {
                 flags: link_msg.header.flags.bits(),
                 transmit_speed: None,
                 receive_speed: None,
+                stats: None,
                 #[cfg(feature = "gateway")]
                 gateway: None,
                 #[cfg(feature = "gateway")]

--- a/src/interface/android.rs
+++ b/src/interface/android.rs
@@ -66,7 +66,7 @@ pub mod netlink {
         mac::MacAddr,
     };
 
-    use crate::stats::{InterfaceStats, get_stats};
+    use crate::stats::{get_stats, InterfaceStats};
 
     pub fn unix_interfaces() -> Vec<Interface> {
         let mut ifaces = Vec::new();

--- a/src/interface/unix.rs
+++ b/src/interface/unix.rs
@@ -4,7 +4,7 @@ use super::MacAddr;
 use crate::gateway;
 use crate::interface::InterfaceType;
 use crate::ipnet::{Ipv4Net, Ipv6Net};
-use crate::stats::{InterfaceStats, get_stats};
+use crate::stats::{get_stats, InterfaceStats};
 use crate::sys;
 use libc;
 use std::ffi::{CStr, CString};

--- a/src/interface/windows.rs
+++ b/src/interface/windows.rs
@@ -14,6 +14,7 @@ use crate::device::NetworkDevice;
 use crate::interface::{Interface, InterfaceType};
 use crate::ipnet::{Ipv4Net, Ipv6Net};
 use crate::mac::MacAddr;
+use crate::stats::InterfaceStats;
 use crate::sys;
 use std::ffi::CStr;
 use std::mem::MaybeUninit;
@@ -265,6 +266,7 @@ pub fn interfaces() -> Vec<Interface> {
                 IpAddr::V4(local_ipv4) => ipv4_vec.iter().any(|x| x.addr() == local_ipv4),
                 IpAddr::V6(local_ipv6) => ipv6_vec.iter().any(|x| x.addr() == local_ipv6),
             };
+            let stats: Option<InterfaceStats> = crate::stats::get_stats_from_index(index);
             let interface: Interface = Interface {
                 index,
                 name: adapter_name,
@@ -278,6 +280,7 @@ pub fn interfaces() -> Vec<Interface> {
                 flags,
                 transmit_speed: sys::sanitize_u64(cur.TransmitLinkSpeed),
                 receive_speed: sys::sanitize_u64(cur.ReceiveLinkSpeed),
+                stats,
                 #[cfg(feature = "gateway")]
                 gateway: if default_gateway.mac_addr == MacAddr::zero() {
                     None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@ pub mod gateway;
 pub mod interface;
 mod ip;
 pub mod mac;
-mod sys;
 pub mod stats;
+mod sys;
 
 pub use device::NetworkDevice;
 #[cfg(feature = "gateway")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod interface;
 mod ip;
 pub mod mac;
 mod sys;
+pub mod stats;
 
 pub use device::NetworkDevice;
 #[cfg(feature = "gateway")]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,160 @@
+use std::time::SystemTime;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::Interface;
+
+/// Interface traffic statistics at a given point in time.
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct InterfaceStats {
+    /// Total received bytes on this interface.
+    pub rx_bytes: u64,
+    /// Total transmitted bytes on this interface.
+    pub tx_bytes: u64,
+    /// The system timestamp when this snapshot was taken.
+    /// May be `None` if the platform does not support it.
+    pub timestamp: Option<SystemTime>,
+}
+
+#[cfg(any(
+    target_vendor = "apple",
+    target_os = "openbsd",
+    target_os = "freebsd",
+    target_os = "netbsd"
+))]
+pub(crate) fn get_stats(ifa: Option<&libc::ifaddrs>, _name: &str) -> Option<InterfaceStats> {
+    if let Some(ifa) = ifa {
+        if !ifa.ifa_data.is_null() {
+            let data = unsafe { &*(ifa.ifa_data as *const libc::if_data) };
+            Some(InterfaceStats { 
+                rx_bytes: data.ifi_ibytes as u64, 
+                tx_bytes: data.ifi_obytes as u64, 
+                timestamp: Some(SystemTime::now())
+            })
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub(crate) fn get_stats(_ifa: Option<&libc::ifaddrs>, name: &str) -> Option<InterfaceStats> {
+    get_stats_from_name(name)
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn get_stats_from_name(name: &str) -> Option<InterfaceStats> {
+    use std::fs::read_to_string;
+    let rx_path = format!("/sys/class/net/{}/statistics/rx_bytes", name);
+    let tx_path = format!("/sys/class/net/{}/statistics/tx_bytes", name);
+    let rx_bytes = match read_to_string(rx_path) {
+        Ok(s) => s.trim().parse::<u64>().unwrap_or(0),
+        Err(_) => 0,
+    };
+    let tx_bytes = match read_to_string(tx_path) {
+        Ok(s) => s.trim().parse::<u64>().unwrap_or(0),
+        Err(_) => 0,
+    };
+    Some(InterfaceStats { rx_bytes, tx_bytes, timestamp: Some(SystemTime::now()) })
+}
+
+#[cfg(any(
+    target_vendor = "apple",
+    target_os = "openbsd",
+    target_os = "freebsd",
+    target_os = "netbsd"
+))]
+fn get_stats_from_name(name: &str) -> Option<InterfaceStats> {
+    use std::ffi::CStr;
+    let mut ifap: *mut libc::ifaddrs = std::ptr::null_mut();
+
+    // 1. getifaddrs()
+    if unsafe { libc::getifaddrs(&mut ifap) } != 0 {
+        return None;
+    }
+
+    let mut current = ifap;
+    let mut result = None;
+
+    // 2. Iterate through the list of ifaddrs
+    while !current.is_null() {
+        unsafe {
+            let ifa = &*current;
+
+            if ifa.ifa_name.is_null() {
+                current = ifa.ifa_next;
+                continue;
+            }
+
+            let ifa_name = CStr::from_ptr(ifa.ifa_name).to_string_lossy();
+
+            if ifa_name == name {
+                if !ifa.ifa_data.is_null() {
+                    let data = &*(ifa.ifa_data as *const libc::if_data);
+                    result = Some(InterfaceStats {
+                        rx_bytes: data.ifi_ibytes as u64,
+                        tx_bytes: data.ifi_obytes as u64,
+                        timestamp: Some(SystemTime::now()),
+                    });
+                    break;
+                }
+            }
+
+            current = ifa.ifa_next;
+        }
+    }
+
+    // 3. freeifaddrs()
+    unsafe {
+        libc::freeifaddrs(ifap);
+    }
+
+    result
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) fn get_stats_from_index(index: u32) -> Option<InterfaceStats> {
+    use windows_sys::Win32::NetworkManagement::IpHelper::{GetIfEntry2, MIB_IF_ROW2};
+    use std::mem::zeroed;
+    use std::time::SystemTime;
+
+    let mut row: MIB_IF_ROW2 = unsafe { zeroed() };
+    row.InterfaceIndex = index;
+
+    unsafe {
+        if GetIfEntry2(&mut row) == 0 {
+            Some(InterfaceStats {
+                rx_bytes: row.InOctets as u64,
+                tx_bytes: row.OutOctets as u64,
+                timestamp: Some(SystemTime::now()),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+pub(crate) fn update_interface_stats(iface: &mut Interface) -> std::io::Result<()> {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        iface.stats = get_stats_from_name(iface.name.as_str());
+    }
+    #[cfg(any(
+        target_vendor = "apple",
+        target_os = "openbsd",
+        target_os = "freebsd",
+        target_os = "netbsd"
+    ))]
+    {
+        iface.stats = get_stats_from_name(iface.name.as_str());
+    }
+    #[cfg(target_os = "windows")]
+    {
+        iface.stats = get_stats_from_index(iface.index);
+    }
+    Ok(())
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -28,10 +28,10 @@ pub(crate) fn get_stats(ifa: Option<&libc::ifaddrs>, _name: &str) -> Option<Inte
     if let Some(ifa) = ifa {
         if !ifa.ifa_data.is_null() {
             let data = unsafe { &*(ifa.ifa_data as *const libc::if_data) };
-            Some(InterfaceStats { 
-                rx_bytes: data.ifi_ibytes as u64, 
-                tx_bytes: data.ifi_obytes as u64, 
-                timestamp: Some(SystemTime::now())
+            Some(InterfaceStats {
+                rx_bytes: data.ifi_ibytes as u64,
+                tx_bytes: data.ifi_obytes as u64,
+                timestamp: Some(SystemTime::now()),
             })
         } else {
             None
@@ -59,7 +59,11 @@ fn get_stats_from_name(name: &str) -> Option<InterfaceStats> {
         Ok(s) => s.trim().parse::<u64>().unwrap_or(0),
         Err(_) => 0,
     };
-    Some(InterfaceStats { rx_bytes, tx_bytes, timestamp: Some(SystemTime::now()) })
+    Some(InterfaceStats {
+        rx_bytes,
+        tx_bytes,
+        timestamp: Some(SystemTime::now()),
+    })
 }
 
 #[cfg(any(
@@ -118,9 +122,9 @@ fn get_stats_from_name(name: &str) -> Option<InterfaceStats> {
 
 #[cfg(target_os = "windows")]
 pub(crate) fn get_stats_from_index(index: u32) -> Option<InterfaceStats> {
-    use windows_sys::Win32::NetworkManagement::IpHelper::{GetIfEntry2, MIB_IF_ROW2};
     use std::mem::zeroed;
     use std::time::SystemTime;
+    use windows_sys::Win32::NetworkManagement::IpHelper::{GetIfEntry2, MIB_IF_ROW2};
 
     let mut row: MIB_IF_ROW2 = unsafe { zeroed() };
     row.InterfaceIndex = index;


### PR DESCRIPTION
- Added `InterfaceStats` struct with `rx_bytes`, `tx_bytes`, and `timestamp`
- Implemented platform-specific logic to fetch statistics
- Added `Interface::update_stats()` to refresh stats on demand