### PR TITLE
iOS Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ features = [
     "Win32_NetworkManagement_Ndis",
 ]
 
-[target.'cfg(target_vendor = "apple")'.dependencies]
+[target.'cfg(target_os = "macos")'.dependencies]
 system-configuration = "0.6"
 
 [dev-dependencies]

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -39,7 +39,7 @@ mod linux;
 #[cfg(target_os = "android")]
 mod android;
 
-#[cfg(target_vendor = "apple")]
+#[cfg(target_os = "macos")]
 mod macos;
 #[cfg(feature = "gateway")]
 use crate::device::NetworkDevice;

--- a/src/interface/unix.rs
+++ b/src/interface/unix.rs
@@ -47,7 +47,7 @@ pub fn get_system_dns_conf() -> Vec<IpAddr> {
     }
 }
 
-#[cfg(target_vendor = "apple")]
+#[cfg(all(target_vendor = "apple", target_os = "macos"))]
 pub fn interfaces() -> Vec<Interface> {
     use super::macos;
 
@@ -90,6 +90,11 @@ pub fn interfaces() -> Vec<Interface> {
     }
 
     interfaces
+}
+
+#[cfg(all(target_vendor = "apple", not(target_os = "macos")))]
+pub fn interfaces() -> Vec<Interface> {
+    unix_interfaces()
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]


### PR DESCRIPTION
I'm trying to use [Iroh](https://iroh.network)'s mDNS discovery system on iOS which makes use of `netdev` internally and i'm getting linking errors like the following on iOS.

<details>
  <summary>Error</summary>
  
 ```
Undefined symbols for architecture arm64:
  "_SCDynamicStoreCopyProxies", referenced from:
      system_configuration::dynamic_store::SCDynamicStore::get_proxies::h6a343615dceb13a0 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_SCDynamicStoreCreateRunLoopSource", referenced from:
      system_configuration::dynamic_store::SCDynamicStore::create_run_loop_source::h93b5556a12a80d61 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_SCDynamicStoreCreateWithOptions", referenced from:
      system_configuration::dynamic_store::SCDynamicStore::create::h3ce4e044029009ce in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_SCNetworkInterfaceCopyAll", referenced from:
      system_configuration::network_configuration::get_interfaces::ha04ccafccab54eb0 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_SCNetworkInterfaceGetBSDName", referenced from:
      system_configuration::network_configuration::SCNetworkInterface::bsd_name::hd9b55f459221161a in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_SCNetworkInterfaceGetInterfaceType", referenced from:
      system_configuration::network_configuration::SCNetworkInterface::interface_type_string::hb6687821a5da7aa0 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_SCNetworkInterfaceGetLocalizedDisplayName", referenced from:
      system_configuration::network_configuration::SCNetworkInterface::display_name::h5130bf6a702c608d in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_SCNetworkReachabilityCreateWithAddress", referenced from:
      _$LT$system_configuration..network_reachability..SCNetworkReachability$u20$as$u20$core..convert..From$LT$core..net..socket_addr..SocketAddr$GT$$GT$::from::h11d2dc9dbf0019f4 in libapp.a[669](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.0.rcgu.o)
  "_SCNetworkReachabilityCreateWithAddressPair", referenced from:
      system_configuration::network_reachability::SCNetworkReachability::from_addr_pair::h21e63973591ed9e9 in libapp.a[669](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.0.rcgu.o)
  "_SCNetworkReachabilityCreateWithName", referenced from:
      system_configuration::network_reachability::SCNetworkReachability::from_host::h42c8e3636d2f09ce in libapp.a[669](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.0.rcgu.o)
  "_SCNetworkReachabilityGetFlags", referenced from:
      system_configuration::network_reachability::SCNetworkReachability::reachability::ha2b7da40f142e57c in libapp.a[669](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.0.rcgu.o)
  "_SCNetworkReachabilityScheduleWithRunLoop", referenced from:
      system_configuration::network_reachability::SCNetworkReachability::schedule_with_runloop::h0924883a649e72b1 in libapp.a[669](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.0.rcgu.o)
  "_SCNetworkReachabilityUnscheduleFromRunLoop", referenced from:
      system_configuration::network_reachability::SCNetworkReachability::unschedule_from_runloop::hb1e77b2accf67b70 in libapp.a[669](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.0.rcgu.o)
  "_SCNetworkServiceCopyAll", referenced from:
      system_configuration::network_configuration::SCNetworkService::get_services::h2a5e4a4332a0b8b1 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_SCNetworkServiceGetEnabled", referenced from:
      system_configuration::network_configuration::SCNetworkService::enabled::h94edd3799ad52259 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_SCNetworkServiceGetInterface", referenced from:
      system_configuration::network_configuration::SCNetworkService::network_interface::h2a32bc99a8033ee1 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_SCNetworkServiceGetServiceID", referenced from:
      system_configuration::network_configuration::SCNetworkService::id::h90e58d24d1cbbe1e in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_SCNetworkSetCopyCurrent", referenced from:
      system_configuration::network_configuration::SCNetworkSet::new::h0539deb00ca38053 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_SCNetworkSetGetServiceOrder", referenced from:
      system_configuration::network_configuration::SCNetworkSet::service_order::h8d036015e25a1b0c in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_SCPreferencesCreate", referenced from:
      system_configuration::preferences::SCPreferences::new::h4157260b14a766cc in libapp.a[669](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.0.rcgu.o)
  "_kSCNetworkInterfaceType6to4", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_kSCNetworkInterfaceTypeBluetooth", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_kSCNetworkInterfaceTypeBond", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_kSCNetworkInterfaceTypeEthernet", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_kSCNetworkInterfaceTypeFireWire", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_kSCNetworkInterfaceTypeIEEE80211", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_kSCNetworkInterfaceTypeIPSec", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_kSCNetworkInterfaceTypeIPv4", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_kSCNetworkInterfaceTypeL2TP", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_kSCNetworkInterfaceTypeModem", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_kSCNetworkInterfaceTypePPP", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_kSCNetworkInterfaceTypePPTP", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_kSCNetworkInterfaceTypeSerial", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_kSCNetworkInterfaceTypeVLAN", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
  "_kSCNetworkInterfaceTypeWWAN", referenced from:
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
      system_configuration::network_configuration::SCNetworkInterfaceType::from_cfstring::hbc5c1ee2b489f123 in libapp.a[670](system_configuration-76dfe2d322c5ec7f.system_configuration.dcbc5f29dfb81df1-cgu.1.rcgu.o)
ld: symbol(s) not found for architecture arm64
```
</details>

This is due to `netdev` using functionality from [`SystemConfiguration`](https://developer.apple.com/documentation/systemconfiguration) which is not supported on iOS. For example [SCNetworkInterfaceCopyAll](https://developer.apple.com/documentation/systemconfiguration/scnetworkinterfacecopyall()) which is used via `network_configuration::get_interfaces`.

This PR adds a special implementation for all Apple operating systems that aren't macOS. I can't verify on anything other than iOS but we can be pretty sure the current code doesn't work as Apple report `SCNetworkInterfaceCopyAll` to only be supported on macOS.