### PR TITLE
Add support for interface operstate

### DIFF
--- a/examples/default_interface.rs
+++ b/examples/default_interface.rs
@@ -18,7 +18,7 @@ fn main() {
             println!("\t\tis TUN {}", interface.is_tun());
             println!("\t\tis RUNNING {}", interface.is_running());
             println!("\t\tis PHYSICAL {}", interface.is_physical());
-            println!("\tOperational state: {:?}", interface.oper_state());
+            println!("\tOperational state: {:?}", interface.oper_state);
             if let Some(mac_addr) = interface.mac_addr {
                 println!("\tMAC Address: {}", mac_addr);
             } else {

--- a/examples/default_interface.rs
+++ b/examples/default_interface.rs
@@ -18,6 +18,7 @@ fn main() {
             println!("\t\tis TUN {}", interface.is_tun());
             println!("\t\tis RUNNING {}", interface.is_running());
             println!("\t\tis PHYSICAL {}", interface.is_physical());
+            println!("\tOperational state: {:?}", interface.oper_state());
             if let Some(mac_addr) = interface.mac_addr {
                 println!("\tMAC Address: {}", mac_addr);
             } else {

--- a/examples/list_interfaces.rs
+++ b/examples/list_interfaces.rs
@@ -18,6 +18,7 @@ fn main() {
         println!("\t\tis TUN {}", interface.is_tun());
         println!("\t\tis RUNNING {}", interface.is_running());
         println!("\t\tis PHYSICAL {}", interface.is_physical());
+        println!("\tOperational state: {:?}", interface.oper_state);
         if let Some(mac_addr) = interface.mac_addr {
             println!("\tMAC Address: {}", mac_addr);
         } else {

--- a/src/interface/android.rs
+++ b/src/interface/android.rs
@@ -62,7 +62,7 @@ pub mod netlink {
     };
 
     use crate::{
-        interface::{Interface, InterfaceType, OperState, Ipv4Net, Ipv6Net},
+        interface::{Interface, InterfaceType, Ipv4Net, Ipv6Net, OperState},
         mac::MacAddr,
     };
 

--- a/src/interface/android.rs
+++ b/src/interface/android.rs
@@ -62,7 +62,7 @@ pub mod netlink {
     };
 
     use crate::{
-        interface::{Interface, InterfaceType, Ipv4Net, Ipv6Net},
+        interface::{Interface, InterfaceType, OperState, Ipv4Net, Ipv6Net},
         mac::MacAddr,
     };
 
@@ -109,6 +109,7 @@ pub mod netlink {
                 ipv6: Vec::new(),
                 ipv6_scope_ids: Vec::new(),
                 flags: link_msg.header.flags.bits(),
+                oper_state: OperState::from_if_flags(link_msg.header.flags.bits()),
                 transmit_speed: None,
                 receive_speed: None,
                 stats: None,

--- a/src/interface/linux.rs
+++ b/src/interface/linux.rs
@@ -1,4 +1,4 @@
-use crate::interface::InterfaceType;
+use crate::interface::{InterfaceType, OperState};
 use std::convert::TryFrom;
 use std::fs::{read_link, read_to_string};
 
@@ -70,4 +70,12 @@ pub fn get_interface_speed(if_name: &str) -> Option<u64> {
             return None;
         }
     };
+}
+
+pub fn operstate(if_name: &str) -> OperState {
+    let path = format!("/sys/class/net/{}/operstate", if_name);
+    match read_to_string(path) {
+        Ok(content) => content.trim().parse().unwrap_or(OperState::Unknown),
+        Err(_) => OperState::Unknown,
+    }
 }

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -88,6 +88,8 @@ pub struct Interface {
     pub ipv6_scope_ids: Vec<u32>,
     /// Flags for the network interface (OS Specific)
     pub flags: u32,
+    /// Operational state at the time of interface discovery
+    pub oper_state: OperState,
     /// Speed in bits per second of the transmit for the network interface, if known.
     /// Currently only supported on Linux, Android, and Windows.
     pub transmit_speed: Option<u64>,
@@ -162,6 +164,7 @@ impl Interface {
             ipv6: Vec::new(),
             ipv6_scope_ids: Vec::new(),
             flags: 0,
+            oper_state: OperState::Unknown,
             transmit_speed: None,
             receive_speed: None,
             stats: None,
@@ -210,11 +213,15 @@ impl Interface {
     }
     /// Get the operational state of the network interface
     pub fn oper_state(&self) -> OperState {
-        operstate(&self.name)
+        self.oper_state
     }
     /// Check if the operational state of the interface is up
     pub fn is_oper_up(&self) -> bool {
-        self.oper_state() == OperState::Up
+        self.oper_state == OperState::Up
+    }
+    /// Update the `oper_state` field by re-reading the current operstate from the system
+    pub fn update_oper_state(&mut self) {
+        self.oper_state = operstate(&self.name);
     }
     /// Returns a list of IPv4 addresses assigned to this interface.
     pub fn ipv4_addrs(&self) -> Vec<Ipv4Addr> {

--- a/src/interface/mod.rs
+++ b/src/interface/mod.rs
@@ -6,6 +6,9 @@ pub use self::shared::*;
 mod types;
 pub use self::types::*;
 
+mod state;
+pub use self::state::*;
+
 #[cfg(any(
     target_os = "linux",
     target_vendor = "apple",
@@ -204,6 +207,14 @@ impl Interface {
         is_physical_interface(&self)
             && !crate::db::oui::is_virtual_mac(&self.mac_addr.unwrap_or(MacAddr::zero()))
             && !crate::db::oui::is_known_loopback_mac(&self.mac_addr.unwrap_or(MacAddr::zero()))
+    }
+    /// Get the operational state of the network interface
+    pub fn oper_state(&self) -> OperState {
+        operstate(&self.name)
+    }
+    /// Check if the operational state of the interface is up
+    pub fn is_oper_up(&self) -> bool {
+        self.oper_state() == OperState::Up
     }
     /// Returns a list of IPv4 addresses assigned to this interface.
     pub fn ipv4_addrs(&self) -> Vec<Ipv4Addr> {

--- a/src/interface/state.rs
+++ b/src/interface/state.rs
@@ -1,6 +1,9 @@
 use std::fmt;
 use std::str::FromStr;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Operational state of a network interface.
 /// 
 /// See also:

--- a/src/interface/state.rs
+++ b/src/interface/state.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::str::FromStr;
+use crate::sys;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -38,6 +39,19 @@ impl OperState {
             OperState::Testing => "testing",
             OperState::Dormant => "dormant",
             OperState::Up => "up",
+        }
+    }
+    pub fn from_if_flags(if_flags: u32) -> Self {
+        // Determine the operational state based on interface flags.
+        // This is a fallback for when the operstate not available.
+        if if_flags & sys::IFF_UP as u32 != 0 {
+            if if_flags & sys::IFF_RUNNING as u32 != 0 {
+                OperState::Up
+            } else {
+                OperState::Dormant
+            }
+        } else {
+            OperState::Down
         }
     }
 }

--- a/src/interface/state.rs
+++ b/src/interface/state.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 /// Operational state of a network interface.
-/// 
+///
 /// See also:
 /// https://www.kernel.org/doc/Documentation/networking/operstates.txt
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]

--- a/src/interface/state.rs
+++ b/src/interface/state.rs
@@ -1,0 +1,63 @@
+use std::fmt;
+use std::str::FromStr;
+
+/// Operational state of a network interface.
+/// 
+/// See also:
+/// https://www.kernel.org/doc/Documentation/networking/operstates.txt
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum OperState {
+    /// Interface state is unknown
+    Unknown,
+    /// Interface is not present
+    NotPresent,
+    /// Interface is administratively or otherwise down
+    Down,
+    /// Interface is down because a lower layer is down
+    LowerLayerDown,
+    /// Interface is in testing state
+    Testing,
+    /// Interface is dormant
+    Dormant,
+    /// Interface is operational
+    Up,
+}
+
+impl OperState {
+    /// Return lowercase string representation matching `/sys/class/net/*/operstate`
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OperState::Unknown => "unknown",
+            OperState::NotPresent => "notpresent",
+            OperState::Down => "down",
+            OperState::LowerLayerDown => "lowerlayerdown",
+            OperState::Testing => "testing",
+            OperState::Dormant => "dormant",
+            OperState::Up => "up",
+        }
+    }
+}
+
+impl fmt::Display for OperState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl FromStr for OperState {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "unknown" => Ok(OperState::Unknown),
+            "notpresent" => Ok(OperState::NotPresent),
+            "down" => Ok(OperState::Down),
+            "lowerlayerdown" => Ok(OperState::LowerLayerDown),
+            "testing" => Ok(OperState::Testing),
+            "dormant" => Ok(OperState::Dormant),
+            "up" => Ok(OperState::Up),
+            _ => Err(()),
+        }
+    }
+}

--- a/src/interface/state.rs
+++ b/src/interface/state.rs
@@ -1,6 +1,6 @@
+use crate::sys;
 use std::fmt;
 use std::str::FromStr;
-use crate::sys;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -50,8 +50,7 @@ impl OperState {
     /// On Windows, this method is **not used** in practice, as the `OperState` is
     /// obtained through native API calls.
     pub fn from_if_flags(if_flags: u32) -> Self {
-        
-        #[cfg(not(target_os = "windows"))] 
+        #[cfg(not(target_os = "windows"))]
         {
             if if_flags & sys::IFF_UP as u32 != 0 {
                 if if_flags & sys::IFF_RUNNING as u32 != 0 {
@@ -64,7 +63,7 @@ impl OperState {
             }
         }
 
-        #[cfg(target_os = "windows")] 
+        #[cfg(target_os = "windows")]
         {
             if if_flags & sys::IFF_UP as u32 != 0 {
                 OperState::Up

--- a/src/interface/unix.rs
+++ b/src/interface/unix.rs
@@ -374,10 +374,7 @@ pub fn get_interface_flags(if_name: &str) -> std::io::Result<u32> {
             Ok(unsafe { ifr.ifru_flags[0] as u32 })
         }
 
-        #[cfg(all(
-            not(target_vendor = "apple"),
-            not(target_os = "netbsd")
-        ))]
+        #[cfg(all(not(target_vendor = "apple"), not(target_os = "netbsd")))]
         {
             Ok(unsafe { ifr.ifr_ifru.ifru_flags[0] as u32 })
         }

--- a/src/interface/unix.rs
+++ b/src/interface/unix.rs
@@ -369,7 +369,15 @@ pub fn get_interface_flags(if_name: &str) -> std::io::Result<u32> {
             Ok(unsafe { ifr.ifr_ifru.ifru_flags as u32 })
         }
 
-        #[cfg(not(target_vendor = "apple"))]
+        #[cfg(target_os = "netbsd")]
+        {
+            Ok(unsafe { ifr.ifru_flags[0] as u32 })
+        }
+
+        #[cfg(all(
+            not(target_vendor = "apple"),
+            not(target_os = "netbsd")
+        ))]
         {
             Ok(unsafe { ifr.ifr_ifru.ifru_flags[0] as u32 })
         }

--- a/src/interface/unix.rs
+++ b/src/interface/unix.rs
@@ -370,9 +370,7 @@ pub use super::linux::operstate;
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub fn operstate(if_name: &str) -> OperState {
     match get_interface_flags(if_name) {
-        Ok(flags) => {
-            OperState::from_if_flags(flags)
-        }
+        Ok(flags) => OperState::from_if_flags(flags),
         Err(_) => OperState::Unknown,
     }
 }

--- a/src/interface/windows.rs
+++ b/src/interface/windows.rs
@@ -254,6 +254,18 @@ pub fn interfaces() -> Vec<Interface> {
                 }
                 _ => {}
             }
+
+            let oper_state: OperState = match cur.OperStatus {
+                1 => OperState::Up,
+                2 => OperState::Down,
+                3 => OperState::Testing,
+                4 => OperState::Unknown,
+                5 => OperState::Dormant,
+                6 => OperState::NotPresent,
+                7 => OperState::LowerLayerDown,
+                _ => OperState::Unknown,
+            };
+
             // Name
             let adapter_name = unsafe { CStr::from_ptr(cur.AdapterName.cast()) }
                 .to_string_lossy()
@@ -332,6 +344,7 @@ pub fn interfaces() -> Vec<Interface> {
                 ipv6: ipv6_vec,
                 ipv6_scope_ids: ipv6_scope_id_vec,
                 flags,
+                oper_state,
                 transmit_speed: sys::sanitize_u64(cur.TransmitLinkSpeed),
                 receive_speed: sys::sanitize_u64(cur.ReceiveLinkSpeed),
                 stats,

--- a/src/interface/windows.rs
+++ b/src/interface/windows.rs
@@ -11,7 +11,7 @@ use windows_sys::Win32::Networking::WinSock::{
 };
 
 use crate::device::NetworkDevice;
-use crate::interface::{Interface, InterfaceType};
+use crate::interface::{Interface, InterfaceType, OperState};
 use crate::ipnet::{Ipv4Net, Ipv6Net};
 use crate::mac::MacAddr;
 use crate::stats::InterfaceStats;
@@ -73,6 +73,58 @@ unsafe fn socket_address_to_ipaddr(addr: &SOCKET_ADDRESS) -> (Option<IpAddr>, Op
 
 pub fn is_running(interface: &Interface) -> bool {
     interface.is_up()
+}
+
+/// Return the operational state of a given Windows interface by its adapter name (GUID string)
+pub fn operstate(if_name: &str) -> OperState {
+    let mut mem = Vec::<u8>::with_capacity(15000);
+    let mut retries = 3;
+    loop {
+        let mut dwsize = mem.capacity() as u32;
+        let ret = unsafe {
+            GetAdaptersAddresses(
+                AF_UNSPEC as u32,
+                GAA_FLAG_INCLUDE_GATEWAYS,
+                std::ptr::null_mut(),
+                mem.as_mut_ptr().cast(),
+                &mut dwsize,
+            )
+        };
+        match ret {
+            0 => {
+                unsafe {
+                    mem.set_len(dwsize as usize);
+                }
+                break;
+            }
+            111 if retries > 0 => {
+                mem.reserve(dwsize as usize);
+                retries -= 1;
+            }
+            _ => return OperState::Unknown,
+        }
+    }
+
+    let ptr = mem.as_mut_ptr() as *mut IP_ADAPTER_ADDRESSES_LH;
+    for cur in unsafe { crate::sys::linked_list_iter!(&ptr) } {
+        let adapter_name = unsafe {
+            CStr::from_ptr(cur.AdapterName.cast()).to_string_lossy().to_string()
+        };
+        if adapter_name == if_name {
+            return match cur.OperStatus {
+                1 => OperState::Up,
+                2 => OperState::Down,
+                3 => OperState::Testing,
+                4 => OperState::Unknown,
+                5 => OperState::Dormant,
+                6 => OperState::NotPresent,
+                7 => OperState::LowerLayerDown,
+                _ => OperState::Unknown,
+            };
+        }
+    }
+
+    OperState::Unknown
 }
 
 /// Check if a network interface has a connector present, indicating it is a physical interface.

--- a/src/interface/windows.rs
+++ b/src/interface/windows.rs
@@ -127,7 +127,9 @@ pub fn operstate(if_name: &str) -> OperState {
     let ptr = mem.as_mut_ptr() as *mut IP_ADAPTER_ADDRESSES_LH;
     for cur in unsafe { linked_list_iter!(&ptr) } {
         let adapter_name = unsafe {
-            CStr::from_ptr(cur.AdapterName.cast()).to_string_lossy().to_string()
+            CStr::from_ptr(cur.AdapterName.cast())
+                .to_string_lossy()
+                .to_string()
         };
         if adapter_name == if_name {
             return match cur.OperStatus {

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -12,6 +12,14 @@ pub const AF_INET6: libc::c_int = libc::AF_INET6;
 
 pub use libc::{IFF_BROADCAST, IFF_LOOPBACK, IFF_MULTICAST, IFF_POINTOPOINT, IFF_RUNNING, IFF_UP};
 
+#[cfg(any(
+    target_vendor = "apple",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd"
+))]
+pub const SIOCGIFFLAGS: libc::c_ulong = 0xc0206911;
+
 fn ntohs(u: u16) -> u16 {
     u16::from_be(u)
 }


### PR DESCRIPTION
Support for retrieving the operational state (OperState) of network interfaces across platforms, including Linux (/sys/class/net), macOS, *BSD (via ioctl), and Windows (native API).

- Adds `OperState` enum
- Add `oper_state` field to `Interface`
- Retrieves operstate at interface discovery time
- Allows refreshing interface status via `Interface::update_oper_state()`