### PR TITLE
fix: Replace hard assertion on SendARP output length with a regular check in the enclosing if statement

### DIFF
--- a/src/interface/windows.rs
+++ b/src/interface/windows.rs
@@ -60,8 +60,7 @@ fn get_mac_through_arp(src_ip: Ipv4Addr, dst_ip: Ipv4Addr) -> MacAddr {
             &mut out_buf_len,
         )
     };
-    if res == NO_ERROR {
-        assert_eq!(out_buf_len, 6);
+    if res == NO_ERROR && out_buf_len == 6 {
         MacAddr::from_octets(unsafe { target_mac_addr.assume_init() })
     } else {
         MacAddr::zero()


### PR DESCRIPTION
This PR removes the unconditional `assert_eq!(out_buf_len, 6)` when retrieving a MAC address via `SendARP` on Windows.  

I encountered an error with a virtual network adapter that a zero was set as MAC length, which caused a panic at runtime. With this change, the assertion is instead a part of the if statement checking for errors.