### PR TITLE
fix(macos): drain autoreleased CoreWLAN objects in get_wifi_transmit_rate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ objc2-system-configuration = { version = "0.3", features = ["SCNetworkConfigurat
 plist = "1.8"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+objc2 = { version = "0.6" }
 objc2-core-wlan = { version = "0.3" }
 objc2-foundation = { version = "0.3" }
 

--- a/src/os/macos/wifi.rs
+++ b/src/os/macos/wifi.rs
@@ -1,14 +1,26 @@
+use objc2::rc::autoreleasepool;
 use objc2_core_wlan::CWWiFiClient;
 use objc2_foundation::NSString;
 
 /// Returns the macOS Wi-Fi transmit rate in bps for the given interface name.
+///
+/// The CoreWLAN calls below produce autoreleased Obj-C/XPC objects
+/// (`CWFRequestParameters`, `CWFInterface`, the `CWFXPCRequestProtocolCoreWLAN`
+/// proxy). This is called from long-lived threads with no draining autorelease
+/// pool (e.g. `netwatch`'s interface monitor re-enumerates on every network
+/// event), so without an explicit pool those objects are added to a pool that
+/// never drains and accumulate without bound — a steady multi-MB/hour macOS
+/// leak. A scoped pool per call frees them immediately.
 pub(crate) fn get_wifi_transmit_rate(iface_name: &str) -> Option<u64> {
-    let client = unsafe { CWWiFiClient::sharedWiFiClient() };
-    let name = NSString::from_str(iface_name);
+    autoreleasepool(|_pool| {
+        let client = unsafe { CWWiFiClient::sharedWiFiClient() };
+        let name = NSString::from_str(iface_name);
 
-    let wifi_iface = unsafe { client.interfaceWithName(Some(&name)) };
-    wifi_iface.map(|i| {
-        let transmit_rate = unsafe { i.transmitRate() };
-        return (transmit_rate * 1e6) as u64;
+        let wifi_iface = unsafe { client.interfaceWithName(Some(&name)) };
+        wifi_iface.map(|i| {
+            let transmit_rate = unsafe { i.transmitRate() };
+            (transmit_rate * 1e6) as u64
+        })
     })
 }
+


### PR DESCRIPTION
## Problem

On macOS, `get_wifi_transmit_rate` (`src/os/macos/wifi.rs`, called from
`interface()` to populate `transmit_speed`) queries CoreWLAN —
`CWWiFiClient::sharedWiFiClient()` → `interfaceWithName` → `transmitRate` —
**without an enclosing autorelease pool**. Those calls produce autoreleased
Obj-C / XPC objects.

When `netdev` is driven from a long-lived thread that has no run loop and no
draining autorelease pool, those objects are added to a top-level pool that
never drains, so they accumulate without bound. This happens in practice via
[`netwatch`](https://crates.io/crates/netwatch) (and thus `iroh`), whose
interface monitor calls `get_interfaces()` on every network change.

## Evidence

`heap <pid>` on a ~7h process using `netdev` through `netwatch` — CoreWLAN /
CoreWiFi objects dominate the heap (~73 MB):

| count | bytes | class |
|---|---|---|
| 298,213 | 33.4 MB | `CWFRequestParameters` (CoreWiFi) |
| 223,658 | 17.9 MB | `__NSXPCInterfaceProxy_CWFXPCRequestProtocolCoreWLAN` |
| 74,555 | 3.6 MB | `CWFInterface` (CoreWiFi) |

RSS climbed ~18 MB/h, linear, no plateau. Linux hosts running the same software
were flat (their path is sysfs, no CoreWLAN), confirming the source.

## Fix

Wrap the body in `objc2::rc::autoreleasepool` so each call drains its
autoreleased objects immediately (adds `objc2` to the macOS deps for the pool
API). Behavior-preserving — the returned rate is unchanged; only the
autoreleased temporaries are freed per call.

## Validation

Same software, only the patch differs:
- **Before:** `CWFRequestParameters` → 298,213 over 7h (~18 MB/h RSS climb).
- **After:** `CWFRequestParameters` pinned at 3, RSS flat (held 30+ min on a
  multi-host fleet, plus a separate long local run).

## Reproducing

A unit test doesn't reproduce it — a synchronous in-process loop frees the
objects promptly (measured 0 growth over 100k calls); the leak is specific to
the async, threaded, over-time CoreWLAN XPC traffic on a pool-less long-lived
thread. To see it by hand on macOS: run a long-lived process that drives
`netdev::get_interfaces()` from a background monitor (e.g. via `netwatch` /
`iroh`) and watch `heap <pid> | grep CWFRequestParameters` climb; with the patch
it stays at a small constant.
