### PR TITLE
link_speed.rs: fix build on 64-bit besides amd64 on FreeBSD

### DIFF
--- a/src/os/unix/link_speed.rs
+++ b/src/os/unix/link_speed.rs
@@ -106,7 +106,7 @@ const SIOCGIFXMEDIA: u64 = 0xc02c6948;
 // #define SIOCGIFMEDIA    _IOWR('i', 56, struct ifmediareq)
 // const SIOCGIFMEDIA: u64 = 0xc02c6938;
 
-#[cfg(all(target_os = "freebsd", target_arch = "x86_64"))]
+#[cfg(all(target_os = "freebsd", target_pointer_width = "64"))]
 // https://github.com/freebsd/freebsd-src/blob/master/sys/sys/sockio.h#L139
 // #define	SIOCGIFXMEDIA	_IOWR('i', 139, struct ifmediareq)
 const SIOCGIFXMEDIA: u64 = 0xc030698b;


### PR DESCRIPTION
The relevant code applies to any 64-bit architecture. Tested on powerpc64le.